### PR TITLE
Added Launcher.Test project. Started adding tests for GameVersion

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,28 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,6 +41,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         name: build-artifacts
     - name: Restore dependencies
-    run: dotnet restore
+      run: dotnet restore
     - name: Test
       run: dotnet test --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx" --results-directory TestResults
     - name: Upload test results

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,20 +3,16 @@
 
 name: .NET
 
-on:
-  push:
-    branches: [ "*" ]
-  pull_request:
-    branches: [ "*" ]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
@@ -36,27 +32,29 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
-    - name: Restore dependencies
-      run: dotnet restore
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
         name: build-artifacts
+    - name: Restore dependencies
+    run: dotnet restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal --logger trx --results-directory TestResults
+      run: dotnet test --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx" --results-directory TestResults
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results
         path: TestResults/
-    - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()
+    - name: Report Test Results
+      uses: dorny/test-reporter@v3
+      if: !cancelled()
       with:
-        files: TestResults/**/*.trx
+        name: Tests
+        path: TestResults/**/*.trx
+        reporter: dotnet-trx

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,11 +3,7 @@
 
 name: .NET
 
-on:
-  push:
-    branches: ["*"]
-  pull_request:
-    branches: ["*"]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -57,7 +53,7 @@ jobs:
         path: TestResults/
     - name: Report Test Results
       uses: dorny/test-reporter@v3
-      if: !cancelled()
+      if: always()
       with:
         name: Tests
         path: TestResults/**/*.trx

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,7 +3,11 @@
 
 name: .NET
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -24,5 +23,38 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-artifacts
+        path: |
+          **/bin/**
+          **/obj/**
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-artifacts
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --logger trx --results-directory TestResults
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: TestResults/
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: TestResults/**/*.trx

--- a/Ksp2Redux.Tools.Installer/Ksp2Redux.Tools.Installer.csproj
+++ b/Ksp2Redux.Tools.Installer/Ksp2Redux.Tools.Installer.csproj
@@ -12,6 +12,7 @@
         <UseWPF>true</UseWPF>
         <RootNamespace>Ksp2Redux.Tools</RootNamespace>
         <NoWarn>$(NoWarn);WPF0001</NoWarn>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
@@ -79,6 +79,14 @@ public class GameVersionTest
     // { }
     //
     // [Test]
+    // public void FromVersionIDType_ReduxNoChannelNameField_ThrowsException()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_StockNoChannelNameField_StableChannel()
+    // { }
+    //
+    // [Test]
     // public void FromVersionIDType_ReduxNullChannelName_StableChannel()
     // { }
     //

--- a/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
@@ -16,7 +16,7 @@ public class GameVersionTest
         // Arrange
         TypeDefinition versionIDType = GenerateMockVersionID(
             ("VERSION_TEXT", version + "." + buildNumber),
-            ("DEBUG_INFO", "_")
+            ("DEBUG_INFO", "0000")
         );
 
         // Act
@@ -46,7 +46,7 @@ public class GameVersionTest
         TypeDefinition versionIDType = GenerateMockVersionID(
             ("VERSION_TEXT", version + "." + buildNumber),
             ("CHANNEL_NAME", channel),
-            ("DEBUG_INFO", "_")
+            ("DEBUG_INFO", "0000")
         );
 
         // Act
@@ -61,50 +61,222 @@ public class GameVersionTest
         Assert.That(result.VersionNumber, Is.EqualTo(expectedVersion));
         Assert.That(result.BuildNumber, Is.EqualTo(expectedBuildNumber));
     }
+
+    [Test]
+    public void FromVersionIDType_NoVersionTextField_ThrowsInvalidOperation(
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("CHANNEL_NAME", "stable"),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, isRedux);
+        });
+    }
+
+    [Test]
+    public void FromVersionIDType_NullOrWhiteSpaceVersionText_ThrowsInvalidOperation(
+        [Values("", " ")]
+        string fullVersionText,
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", fullVersionText),
+            ("CHANNEL_NAME", "stable"),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, isRedux);
+        });
+    }
     
-    // [Test]
-    // public void FromVersionIDType_NoVersionTextField_ThrowsException()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_NullOrWhiteSpaceVersionText_EmptyVersionAndBuildNumber()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_IncorrectVersionParse_ThrowsException()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_IncorrectVersionTokenLength_ThrowsException()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_ReduxNoChannelNameField_ThrowsException()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_StockNoChannelNameField_StableChannel()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_ReduxNullChannelName_StableChannel()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_ReduxWhiteSpaceChannelName_WhiteSpaceChannel()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_NoDebugInfoField_ThrowsException()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_NullDebugInfo_EmptyCommitHash()
-    // { }
-    //
-    // [Test]
-    // public void FromVersionIDType_WhiteSpaceDebugInfo_ChannelPlusWhiteSpaceCommitHash()
-    // { }
+    [Test]
+    public void FromVersionIDType_IncorrectVersionParse_ThrowsInvalidOperation(
+        [Values("a.b.c.d.e", "0.0.0..0", ".0.0.0.0")]
+        string fullVersionText,
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", fullVersionText),
+            ("CHANNEL_NAME", "stable"),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, isRedux);
+        });
+    }
+    
+    [Test]
+    public void FromVersionIDType_IncorrectVersionTokenLength_ThrowsInvalidOperation(
+        [Values("0.0.0.0", "0.0.0.0.0.0")]
+        string fullVersionText,
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", fullVersionText),
+            ("CHANNEL_NAME", "stable"),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, isRedux);
+        });
+    }
+    
+    [Test]
+    public void FromVersionIDType_ReduxNoChannelNameField_ThrowsInvalidOperation()
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, true);
+        });
+    }
+
+    [Test]
+    public void FromVersionIDType_StockNoChannelNameField_StableChannel()
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        GameVersion result = GameVersion.FromVersionIDType(versionIDType, true);
+        
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Channel, Is.EqualTo("stable"));
+    }
+
+    [Test]
+    public void FromVersionIDType_ReduxNullChannelName_ThrowsInvalidOperation()
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("CHANNEL_NAME", null),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, true);
+        });
+    }
+
+    [Test]
+    public void FromVersionIDType_ReduxWhiteSpaceChannelName_ThrowsInvalidOperation(
+        [Values("", " ")]
+        string channelName
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("CHANNEL_NAME", channelName),
+            ("DEBUG_INFO", "0000")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, true);
+        });
+    }
+
+    [Test]
+    public void FromVersionIDType_NoDebugInfoField_ThrowsInvalidOperation(
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("CHANNEL_NAME", "stable")
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, isRedux);
+        });
+    }
+
+    [Test]
+    public void FromVersionIDType_NullDebugInfo_ThrowsInvalidOperation(
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("CHANNEL_NAME", "stable"),
+            ("DEBUG_INFO", null)
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, isRedux);
+        });
+    }
+    
+    [Test]
+    public void FromVersionIDType_WhiteSpaceDebugInfo_ThrowsInvalidOperation(
+        [Values("", " ")]
+        string debugInfo,
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("CHANNEL_NAME", "stable"),
+            ("DEBUG_INFO", debugInfo)
+        );
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            GameVersion.FromVersionIDType(versionIDType, isRedux);
+        });
+    }
     
     [Test]
     public void FromVersionIDType_DebugInfoIsBuildInfo_EmptyCommitHash(
@@ -279,7 +451,7 @@ public class GameVersionTest
     
     
     
-    private static TypeDefinition GenerateMockVersionID(params List<(string name, string value)> fields)
+    private static TypeDefinition GenerateMockVersionID(params List<(string name, string? value)> fields)
     {
         AssemblyDefinition? assembly = AssemblyDefinition.CreateAssembly(
             new AssemblyNameDefinition("MockAssembly", new Version(1, 0, 0, 0)),

--- a/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
@@ -1,0 +1,304 @@
+﻿using Ksp2Redux.Tools.Launcher.Models;
+using Mono.Cecil;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class GameVersionTest
+{
+    [Test]
+    public void FromVersionIDType_CorrectVersionStock_CorrectGameVersionStableChannel(
+        [Values("0.0.0.0", "1.2.3.4", "10.20.30.40")]
+        string version,
+        [Values("0", "12350")]
+        string buildNumber
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", version + "." + buildNumber),
+            ("DEBUG_INFO", "_")
+        );
+
+        // Act
+        GameVersion result = GameVersion.FromVersionIDType(versionIDType, false);
+        
+        // Assert
+        Version expectedVersion = Version.Parse(version);
+        string expectedBuildNumber = buildNumber;
+        
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Channel, Is.EqualTo("stable"));
+        Assert.That(result.VersionNumber, Is.EqualTo(expectedVersion));
+        Assert.That(result.BuildNumber, Is.EqualTo(expectedBuildNumber));
+    }
+
+    [Test]
+    public void FromVersionIDType_CorrectVersionRedux_CorrectGameVersionAndChannel(
+        [Values("0.0.0.0", "1.2.3.4", "10.20.30.40")]
+        string version,
+        [Values("0", "12350")]
+        string buildNumber,
+        [Values("stable", "beta")]
+        string channel
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", version + "." + buildNumber),
+            ("CHANNEL_NAME", channel),
+            ("DEBUG_INFO", "_")
+        );
+
+        // Act
+        GameVersion result = GameVersion.FromVersionIDType(versionIDType, true);
+        
+        // Assert
+        Version expectedVersion = Version.Parse(version);
+        string expectedBuildNumber = buildNumber;
+        
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Channel, Is.EqualTo(channel));
+        Assert.That(result.VersionNumber, Is.EqualTo(expectedVersion));
+        Assert.That(result.BuildNumber, Is.EqualTo(expectedBuildNumber));
+    }
+    
+    // [Test]
+    // public void FromVersionIDType_NoVersionTextField_ThrowsException()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_NullOrWhiteSpaceVersionText_EmptyVersionAndBuildNumber()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_IncorrectVersionParse_ThrowsException()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_IncorrectVersionTokenLength_ThrowsException()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_ReduxNullChannelName_StableChannel()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_ReduxWhiteSpaceChannelName_WhiteSpaceChannel()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_NoDebugInfoField_ThrowsException()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_NullDebugInfo_EmptyCommitHash()
+    // { }
+    //
+    // [Test]
+    // public void FromVersionIDType_WhiteSpaceDebugInfo_ChannelPlusWhiteSpaceCommitHash()
+    // { }
+    
+    [Test]
+    public void FromVersionIDType_DebugInfoIsBuildInfo_EmptyCommitHash(
+        // In theory this can only happen on stock game, but it should have the same behavior
+        [Values(true, false)]
+        bool isRedux
+    )
+    {
+        // Arrange
+        TypeDefinition versionIDType = GenerateMockVersionID(
+            ("VERSION_TEXT", "0.0.0.0.0"),
+            ("CHANNEL_NAME", "_"),
+            ("DEBUG_INFO", "BUILD_INFO")
+        );
+
+        // Act
+        GameVersion result = GameVersion.FromVersionIDType(versionIDType, isRedux);
+        
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.CommitHash, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void Equals_Null_ReturnsFalse()
+    {
+        // Arrange
+        GameVersion gameVersion = new()
+        {
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "1234",
+        };
+        
+        // Act
+        bool result = gameVersion.Equals(null);
+        
+        // Arrange
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_OnlySameVersionNumber_ReturnsFalse()
+    {
+        // Arrange
+        GameVersion gameVersion1 = new()
+        {
+            Channel = "a",
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "1234",
+            CommitHash = "a"
+        };
+        GameVersion gameVersion2 = new()
+        {
+            Channel = "b",
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "5678",
+            CommitHash = "b"
+        };
+        
+        // Act
+        bool result = gameVersion1.Equals(gameVersion2);
+        
+        // Arrange
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_OnlySameBuildNumber_ReturnsFalse()
+    {
+        // Arrange
+        GameVersion gameVersion1 = new()
+        {
+            Channel = "a",
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "1234",
+            CommitHash = "a"
+        };
+        GameVersion gameVersion2 = new()
+        {
+            Channel = "b",
+            VersionNumber = Version.Parse("1.2.3.4"),
+            BuildNumber = "1234",
+            CommitHash = "b"
+        };
+        
+        // Act
+        bool result = gameVersion1.Equals(gameVersion2);
+        
+        // Arrange
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Equals_OnlySameVersionNumberAndBuildNumber_ReturnsTrue()
+    {
+        // Arrange
+        GameVersion gameVersion1 = new()
+        {
+            Channel = "a",
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "1234",
+            CommitHash = "a"
+        };
+        GameVersion gameVersion2 = new()
+        {
+            Channel = "b",
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "1234",
+            CommitHash = "b"
+        };
+        
+        // Act
+        bool result = gameVersion1.Equals(gameVersion2);
+        
+        // Arrange
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void GetHashCode_SameBuildNumber_SameHash()
+    {
+        // Arrange
+        GameVersion gameVersion1 = new()
+        {
+            Channel = "a",
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "1234",
+            CommitHash = "a"
+        };
+        GameVersion gameVersion2 = new()
+        {
+            Channel = "b",
+            VersionNumber = Version.Parse("1.2.3.4"),
+            BuildNumber = "1234",
+            CommitHash = "b"
+        };
+        
+        // Act
+        int hash1 = gameVersion1.GetHashCode();
+        int hash2 = gameVersion2.GetHashCode();
+        
+        // Arrange
+        Assert.That(hash1, Is.EqualTo(hash2));
+    }
+
+    [Test]
+    public void GetHashCode_DifferentBuildNumber_DifferentHashes()
+    {
+        // Arrange
+        GameVersion gameVersion1 = new()
+        {
+            Channel = "a",
+            VersionNumber = Version.Parse("0.0.0.0"),
+            BuildNumber = "1234",
+            CommitHash = "a"
+        };
+        GameVersion gameVersion2 = new()
+        {
+            Channel = "b",
+            VersionNumber = Version.Parse("1.2.3.4"),
+            BuildNumber = "5678",
+            CommitHash = "b"
+        };
+        
+        // Act
+        int hash1 = gameVersion1.GetHashCode();
+        int hash2 = gameVersion2.GetHashCode();
+        
+        // Arrange
+        Assert.That(hash1, Is.Not.EqualTo(hash2));
+    }
+    
+    
+    
+    private static TypeDefinition GenerateMockVersionID(params List<(string name, string value)> fields)
+    {
+        AssemblyDefinition? assembly = AssemblyDefinition.CreateAssembly(
+            new AssemblyNameDefinition("MockAssembly", new Version(1, 0, 0, 0)),
+            "MockModule", ModuleKind.Dll);
+        ModuleDefinition? module = assembly.MainModule;
+
+        TypeDefinition versionIDType = new(
+            "_", "MockVersionID",
+            TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+
+        foreach (var fieldData in fields)
+        {
+            FieldDefinition field = new(
+                fieldData.name,
+                FieldAttributes.Public |
+                FieldAttributes.Static |
+                FieldAttributes.Literal |
+                FieldAttributes.HasDefault,
+                module.TypeSystem.String)
+            {
+                Constant = fieldData.value
+            };
+            versionIDType.Fields.Add(field);
+        }
+
+        module.Types.Add(versionIDType);
+        return versionIDType;
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="5.0.0-preview0012" />
         <PackageReference Include="coverlet.collector" Version="6.0.4"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>
         <PackageReference Include="Moq" Version="4.20.72" />

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="5.0.0-preview0012" />
+        <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="NUnit" Version="4.3.2"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.7.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Ksp2Redux.Tools.Launcher\Ksp2Redux.Tools.Launcher.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Remove="MockExecutable.sh" />
+    </ItemGroup>
+
+</Project>

--- a/Ksp2Redux.Tools.sln
+++ b/Ksp2Redux.Tools.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ksp2Redux.Tools.Launcher", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ksp2Redux.Tools.Uploader", "Ksp2Redux.Tools.Uploader\Ksp2Redux.Tools.Uploader.csproj", "{E722C163-A1DE-4680-864B-3DA5485387B7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ksp2Redux.Tools.Launcher.Test", "Ksp2Redux.Tools.Launcher.Test\Ksp2Redux.Tools.Launcher.Test.csproj", "{5DA30669-7542-49E0-A624-4E70DDD077A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{E722C163-A1DE-4680-864B-3DA5485387B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E722C163-A1DE-4680-864B-3DA5485387B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E722C163-A1DE-4680-864B-3DA5485387B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DA30669-7542-49E0-A624-4E70DDD077A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DA30669-7542-49E0-A624-4E70DDD077A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DA30669-7542-49E0-A624-4E70DDD077A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DA30669-7542-49E0-A624-4E70DDD077A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Some tests are still just a commented signature.
They correspond to the behavior I understood from the code, but I'm not sure if this is really the intended behavior.
It's mostly about edge cases and error handling, so please tell me how they should be handled.

Edit:
Looking more at the code, I have an opinion of what the expected behavior should be.

- No VERSION_TEXT field:
  - Current: Throws NullReference
  - Expected: Throws InvalidOperation

- null or whitespace VERSION_TEXT:
  - Current: Empty version and build number
  - Expected: Throws InvalidOperation

- Fail to parse Version from VERSION_TEXT:
  - Current: Throws the expection from Version.Parse
  - Expected: Throws InvalidOperation
 
- Incorrect version token length (less than 5):
  - Current: Throws OutOfRange execption
  - Expected: Throws InvalidOperation

- No CHANNEL_NAME on redux build:
  - Current: Throws NullReference
  - Expected: Throws InvalidOperation

- null CHANNEL_NAME on redux build:
  - Current: Release set to "stable"
  - Expected: Throws InvalidOperation

- Whitespace CHANNEL_NAME on redux build:
  - Current: Release set to whitespace
  - Expected: Throws InvalidOperation

- No DEBUG_INFO field:
  - Current: Throws NullReference
  - Expected: Throws InvalidOperation

- null DEBUG_INFO:
  - Current: Empty commit hash
  - Expected: Throws InvalidOperation

- Whitespace DEBUG_INFO:
  - Current: "[channel]+ " as commitHash
  - Expected: Throws InvalidOperation

As you can see, it's a lot about throwing InvalidOperation "The type you wanted to get a GameVersion from did not match the expected criterias" instead of tolerating errors that shouldn't happen.
Tell me if some of the these errors should be treated differently.