### PR TITLE
feature/dotnet-10-upgrade

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -36,7 +36,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       if: steps.check_tag.outputs.exists == 'false'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x 
+        dotnet-version: 10.0.x
 
     - name: Build and Publish
       if: steps.check_tag.outputs.exists == 'false'

--- a/Ksp2Redux.Tools.Common/Ksp2Redux.Tools.Common.csproj
+++ b/Ksp2Redux.Tools.Common/Ksp2Redux.Tools.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -14,7 +14,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.12.0-beta1.25218.8">
+      <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Ksp2Redux.Tools.Installer/App.xaml.cs
+++ b/Ksp2Redux.Tools.Installer/App.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Configuration;
-using System.Data;
-using System.Windows;
+﻿using System.Windows;
 
 namespace Ksp2Redux.Tools;
 

--- a/Ksp2Redux.Tools.Installer/Ksp2Redux.Tools.Installer.csproj
+++ b/Ksp2Redux.Tools.Installer/Ksp2Redux.Tools.Installer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/GameVersionTest.cs
@@ -173,7 +173,7 @@ public class GameVersionTest
         ).type;
 
         // Act
-        GameVersion result = GameVersion.FromVersionIDType(versionIDType, true);
+        GameVersion result = GameVersion.FromVersionIDType(versionIDType, false);
         
         // Assert
         Assert.That(result, Is.Not.Null);

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ConfigTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ConfigTest.cs
@@ -195,6 +195,7 @@ public class ConfigTest
             VersionNumber = new Version(1, 1, 2, 0),
             Channel = "channel-1",
             CommitHash = "1",
+            ReleasedAt = new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc),
         });
         List<GameVersionViewModel> expectedItems =
         [
@@ -205,6 +206,7 @@ public class ConfigTest
                 VersionNumber = new Version(1, 1, 1, 0),
                 Channel = "channel-1",
                 CommitHash = "0",
+                ReleasedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             }),
         ];
         

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ConfigTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ConfigTest.cs
@@ -10,7 +10,6 @@ using Ksp2Redux.Tools.Launcher.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using MsBox.Avalonia.Enums;
-using Testably.Abstractions.Testing;
 
 namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
 

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DownloadTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DownloadTest.cs
@@ -1,16 +1,12 @@
 ﻿using System.IO.Abstractions;
 using System.IO.Compression;
 using System.Net;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
 using Avalonia.Input;
-using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using CodeHollow.FeedReader;

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
@@ -9,19 +9,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Headless.NUnit" Version="12.0.1" />
-        <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+        <PackageReference Include="Avalonia.Headless.NUnit" Version="12.0.4" />
+        <PackageReference Include="coverlet.collector" Version="10.0.1"/>
         <PackageReference Include="EnvironmentAbstractions.BannedApiAnalyzer" Version="5.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="EnvironmentAbstractions.TestHelpers" Version="5.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.7.0"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/>
-        <PackageReference Include="Testably.Abstractions.Testing" Version="6.2.0" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.14.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
+        <PackageReference Include="Testably.Abstractions.Testing" Version="6.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Ksp2Redux.Tools.Launcher.Test/LauncherConfigServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LauncherConfigServiceTest.cs
@@ -90,7 +90,9 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act Assert
-        Assert.Throws<Exception>(() => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object));
+        Assert.That(
+            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object),
+            Throws.Exception);
         directory.Verify(d => d.CreateDirectory("incorrect combined path"), Times.Never,
             "Tried to create a directory for the config when appdata didn't exist");
         file.Verify(d => d.ReadAllText("incorrect combined path"), Times.Never, 
@@ -129,7 +131,9 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act Assert
-        Assert.Throws<Exception>(() => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object));
+        Assert.That(
+            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object),
+            Throws.Exception);
         directory.Verify(d => d.CreateDirectory("incorrect combined path"), Times.Never,
             "Tried to create a directory for the config when appdata didn't exist");
         file.Verify(d => d.ReadAllText("incorrect combined path"), Times.Never, 
@@ -358,7 +362,7 @@ public class LauncherConfigServiceTest
         };
         
         // Act Assert
-        Assert.Throws<Exception>(() => launcherConfigService.Save());
+        Assert.That(() => launcherConfigService.Save(), Throws.Exception);
         directory.Verify(d => d.CreateDirectory(It.IsNotIn("/appdata/Ksp2Redux")), Times.Never, 
             "Tried creating a directory when IPath.GetDirectoryName returned null");
         file.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never,

--- a/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
@@ -1,6 +1,4 @@
-using System;
 using System.IO.Abstractions;
-using System.Linq;
 using Ksp2Redux.Tools.Launcher.Services;
 using Moq;
 using Testably.Abstractions.Testing;

--- a/Ksp2Redux.Tools.Launcher/Controls/GroupedComboBox.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Controls/GroupedComboBox.axaml.cs
@@ -15,6 +15,7 @@ namespace Ksp2Redux.Tools.Launcher.Controls
     {
         private readonly ObservableCollection<object> _groupedItems = [];
         private bool _isRebuilding;
+        private ComboBox? InnerComboBoxControl => this.FindControl<ComboBox>("InnerComboBox");
 
         /// <summary>
         /// The flattened list of headers and items
@@ -65,7 +66,7 @@ namespace Ksp2Redux.Tools.Launcher.Controls
 
         public GroupedComboBox()
         {
-            InitializeComponent();
+            AvaloniaXamlLoader.Load(this);
 
             GroupKeySelector ??= _ => string.Empty;
         }
@@ -118,7 +119,10 @@ namespace Ksp2Redux.Tools.Launcher.Controls
                 _isRebuilding = false;
                 if (SelectedItem != null && _groupedItems.Contains(SelectedItem))
                 {
-                    InnerComboBox.SelectedItem = SelectedItem;
+                    if (InnerComboBoxControl is { } innerComboBox)
+                    {
+                        innerComboBox.SelectedItem = SelectedItem;
+                    }
                 }
             }
         }

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -24,31 +24,31 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.1" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+        <PackageReference Include="Avalonia" Version="12.0.4" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
         <PackageReference Include="Avalonia.HtmlRenderer" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
         <PackageReference Include="CodeHollow.FeedReader" Version="1.2.6" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
         <PackageReference Include="EnvironmentAbstractions" Version="5.0.0" />
         <PackageReference Include="EnvironmentAbstractions.BannedApiAnalyzer" Version="5.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.12.0-beta1.25218.8">
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.3.26207.106" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
         <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
         <PackageReference Include="Mono.Cecil" Version="0.11.6" />
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Testably.Abstractions" Version="10.2.0" />
-        <PackageReference Include="Tomlyn" Version="0.19.0" />
+        <PackageReference Include="Tomlyn" Version="2.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Ksp2Redux.Tools.Launcher/Models/GameVersion.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/GameVersion.cs
@@ -6,7 +6,7 @@ namespace Ksp2Redux.Tools.Launcher.Models;
 
 public class GameVersion : IEquatable<GameVersion>
 {
-    public string Channel { get; set; }
+    public string Channel { get; set; } = "stable";
     public required Version VersionNumber { get; set; }
     public required string BuildNumber { get; set; }
     public string? CommitHash { get; set; }
@@ -22,34 +22,49 @@ public class GameVersion : IEquatable<GameVersion>
         string buildNumber;
         string commitHash;
 
-        string GetFieldValueAsString(string fieldName)
+        string GetRequiredFieldValueAsString(string fieldName)
         {
-            var buffer = versionType.Fields.First(f => f.Name == fieldName).Constant;
-            return buffer.ToString()!;
+            var field = versionType.Fields.FirstOrDefault(f => f.Name == fieldName);
+            if (field?.Constant is not { } value)
+                throw new InvalidOperationException($"VersionID field '{fieldName}' is missing or null.");
+
+            var text = value.ToString();
+            if (string.IsNullOrWhiteSpace(text))
+                throw new InvalidOperationException($"VersionID field '{fieldName}' is empty.");
+
+            return text;
         }
 
         // VERSION_TEXT is common between redux and stock.
         // Stock: "0.2.2.0.32914"
-        var versionText = GetFieldValueAsString("VERSION_TEXT");
-        if (!string.IsNullOrWhiteSpace(versionText))
+        var versionText = GetRequiredFieldValueAsString("VERSION_TEXT");
+        var tokens = versionText.Split('.');
+        if (tokens.Length != 5)
         {
-            var tokens = versionText.Split('.');
+            throw new InvalidOperationException($"VERSION_TEXT must contain five dot-separated tokens: '{versionText}'.");
+        }
+
+        try
+        {
             version = Version.Parse(string.Join('.', tokens[0..4]));
-            buildNumber = tokens[4];
         }
-        else
+        catch (Exception ex) when (ex is ArgumentException or FormatException or OverflowException)
         {
-            version = new();
-            buildNumber = string.Empty;
+            throw new InvalidOperationException($"VERSION_TEXT has an invalid version number: '{versionText}'.", ex);
         }
-        if(IsRedux)
-            if (GetFieldValueAsString("CHANNEL_NAME") is { } channelName)
-                channel = channelName;
-        
+
+        buildNumber = tokens[4];
+        if (string.IsNullOrWhiteSpace(buildNumber))
+            throw new InvalidOperationException($"VERSION_TEXT has an invalid build number: '{versionText}'.");
+
+        if (IsRedux)
+            channel = GetRequiredFieldValueAsString("CHANNEL_NAME");
+
         // try get redux commit hash
-        if (GetFieldValueAsString("DEBUG_INFO") is { } possibleHash && possibleHash != "BUILD_INFO")
+        var possibleHash = GetRequiredFieldValueAsString("DEBUG_INFO");
+        if (possibleHash != "BUILD_INFO")
         {
-            commitHash = $"{channel.ToLower()}+{possibleHash}";
+            commitHash = $"{channel.ToLowerInvariant()}+{possibleHash}";
         }
         else
         {

--- a/Ksp2Redux.Tools.Launcher/Models/InstallPlan.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/InstallPlan.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Ksp2Redux.Tools.Common;
-using Ksp2Redux.Tools.Launcher.Services;
 
 namespace Ksp2Redux.Tools.Launcher.Models;
 

--- a/Ksp2Redux.Tools.Launcher/Models/Ksp2Install.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/Ksp2Install.cs
@@ -1,9 +1,6 @@
-﻿using Mono.Cecil;
-using System;
-using System.IO;
+﻿using System;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Reflection;
 using Ksp2Redux.Tools.Launcher.Services;
 
 namespace Ksp2Redux.Tools.Launcher.Models;

--- a/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
@@ -4,14 +4,9 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Reflection;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Ksp2Redux.Tools.Common;
 using Ksp2Redux.Tools.Launcher.Services;
 
 namespace Ksp2Redux.Tools.Launcher.Models;

--- a/Ksp2Redux.Tools.Launcher/Models/News.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/News.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Tomlyn;
-using Tomlyn.Model;
 
 namespace Ksp2Redux.Tools.Launcher.Models;
 

--- a/Ksp2Redux.Tools.Launcher/Program.cs
+++ b/Ksp2Redux.Tools.Launcher/Program.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using CommandLine;

--- a/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
@@ -121,7 +121,10 @@ public class LauncherConfigService : ILauncherConfigService
     public void Save()
     {
         var directory = _fileSystem.Path.GetDirectoryName(Config.StoragePath);
-        _fileSystem.Directory.CreateDirectory(directory!);
+        if (string.IsNullOrWhiteSpace(directory))
+            throw new InvalidOperationException($"Could not determine config directory from storage path '{Config.StoragePath}'.");
+
+        _fileSystem.Directory.CreateDirectory(directory);
         try
         {
             _fileSystem.File.WriteAllText(Config.StoragePath, JsonSerializer.Serialize(Config, StorageOptions));

--- a/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.IO.Abstractions;
 using System.Text.Json;
 using Ksp2Redux.Tools.Launcher.Models;

--- a/Ksp2Redux.Tools.Launcher/Services/LocalStoragePaths.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LocalStoragePaths.cs
@@ -11,7 +11,9 @@ internal static class LocalStoragePaths
     public static string GetLocalStorageDirectory(IFileSystem fileSystem, IEnvironmentProvider environmentProvider)
     {
         var appdataPath = environmentProvider.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return fileSystem.Path.Combine(appdataPath, ReduxFolder);
+        return string.IsNullOrWhiteSpace(appdataPath) 
+            ? throw new InvalidOperationException("Local application data folder path is unavailable.") 
+            : fileSystem.Path.Combine(appdataPath, ReduxFolder);
     }
 
     public static string GetLogsDirectory(IFileSystem fileSystem, IEnvironmentProvider environmentProvider)

--- a/Ksp2Redux.Tools.Launcher/Services/ModuleDefinitionService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/ModuleDefinitionService.cs
@@ -1,6 +1,4 @@
-﻿
-using System.Xml.Linq;
-using Mono.Cecil;
+﻿using Mono.Cecil;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
 

--- a/Ksp2Redux.Tools.Launcher/Services/NewsProviderService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/NewsProviderService.cs
@@ -1,7 +1,4 @@
-﻿using System.Net.Http;
-using System.ServiceModel.Syndication;
-using System.Threading.Tasks;
-using System.Xml;
+﻿using System.Threading.Tasks;
 using CodeHollow.FeedReader;
 
 namespace Ksp2Redux.Tools.Launcher.Services;

--- a/Ksp2Redux.Tools.Launcher/Services/NewsService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/NewsService.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using CodeHollow.FeedReader;
 using Ksp2Redux.Tools.Launcher.Models;
-using Tomlyn;
-using Tomlyn.Model;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
 

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -5,13 +5,11 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Avalonia.Controls;
-using MsBox.Avalonia;
 using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.Services;

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Threading.Tasks;
-using Ksp2Redux.Tools.Launcher.Models;
-using Ksp2Redux.Tools.Launcher.Services;
+﻿using Ksp2Redux.Tools.Launcher.Services;
 using Ksp2Redux.Tools.Launcher.ViewModels.Shared;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Community;

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/GameVersionViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/GameVersionViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Ksp2Redux.Tools.Launcher.Controls;
+﻿using System.Text;
+using Ksp2Redux.Tools.Launcher.Controls;
 using Ksp2Redux.Tools.Launcher.Models;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Home;
@@ -6,13 +7,20 @@ namespace Ksp2Redux.Tools.Launcher.ViewModels.Home;
 public class GameVersionViewModel(GameVersion gameVersion) : ViewModelBase, IGroupedComboBoxItem
 {
     public string Channel = gameVersion.Channel;
-    public string VersionString => $"v{gameVersion.VersionNumber}.{gameVersion.BuildNumber}" +
-                                   $"{(gameVersion.Channel == "stable"
-                                       ? ""
-                                       : $"-{gameVersion.Channel.ToLower()}")}";
+    public string VersionString => new StringBuilder()
+        .Append('v')
+        .Append(gameVersion.VersionNumber)
+        .Append('.')
+        .Append(gameVersion.BuildNumber)
+        .Append(gameVersion.Channel == "stable"
+            ? string.Empty
+            : new StringBuilder()
+                .Append('-')
+                .Append(gameVersion.Channel.ToLower()).ToString())
+        .ToString();
 
-    public string ReleaseDateString => gameVersion.ReleasedAt is { } d
-        ? d.ToLocalTime().ToString("yyyy-MM-dd")
+    public string ReleaseDateString => gameVersion.ReleasedAt is { } dateTime
+        ? dateTime.ToLocalTime().ToString("yyyy-MM-dd")
         : string.Empty;
 
     public bool HasReleaseDate => gameVersion.ReleasedAt is not null;

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -35,9 +35,9 @@ public partial class HomeTabViewModel : ViewModelBase
     public ObservableCollection<GameVersionViewModel> Versions { get; } = [];
     public ObservableCollection<Ksp2InstallChoiceViewModel> Installs { get; } = [];
 
-    [ObservableProperty] public partial GameVersionViewModel? SelectedVersion { get; set; }
-    [ObservableProperty] public partial Ksp2InstallChoiceViewModel? SelectedInstall { get; set; }
-    [ObservableProperty] public partial bool IsInstallSwitcherEnabled { get; private set; }
+    [ObservableProperty] private GameVersionViewModel? _selectedVersion;
+    [ObservableProperty] private Ksp2InstallChoiceViewModel? _selectedInstall;
+    [ObservableProperty] private bool _isInstallSwitcherEnabled;
 
     public enum MainButtonState
     {
@@ -46,22 +46,22 @@ public partial class HomeTabViewModel : ViewModelBase
         Update,
         Cancel,
     }
-    [ObservableProperty] public partial MainButtonState MainButtonShown { get; private set; }
-    [ObservableProperty] public partial bool MainButtonEnabled { get; private set; }
-    [ObservableProperty] public partial string MainButtonTooltip { get; private set; } = "Loading...";
-    [ObservableProperty] public partial bool IsProgressVisible { get; private set; } = false;
-    [ObservableProperty] public partial float DownloadProgressMb { get; private set; } = 250;
-    [ObservableProperty] public partial float DownloadProgressTotalMb { get; private set; } = 450;
-    [ObservableProperty] public partial float InstallProgressSteps { get; private set; } = 1;
-    [ObservableProperty] public partial float InstallProgressTotalSteps { get; private set; } = 3;
-    [ObservableProperty] public partial bool IsInstallLogVisible { get; private set; } = false;
-    [ObservableProperty] public partial string InstallLogText { get; private set; } = string.Empty;
-    [ObservableProperty] public partial bool InstallationDisabled { get; private set; } = false;
+    [ObservableProperty] private MainButtonState _mainButtonShown;
+    [ObservableProperty] private bool _mainButtonEnabled;
+    [ObservableProperty] private string _mainButtonTooltip = "Loading...";
+    [ObservableProperty] private bool _isProgressVisible;
+    [ObservableProperty] private float _downloadProgressMb = 250;
+    [ObservableProperty] private float _downloadProgressTotalMb = 450;
+    [ObservableProperty] private float _installProgressSteps = 1;
+    [ObservableProperty] private float _installProgressTotalSteps = 3;
+    [ObservableProperty] private bool _isInstallLogVisible;
+    [ObservableProperty] private string _installLogText = string.Empty;
+    [ObservableProperty] private bool _installationDisabled;
+    
     private readonly StringBuilder _installLogBuilder = new();
-    private readonly object _installLogLock = new();
+    private readonly Lock _installLogLock = new();
     private bool _installLogUpdateQueued;
-
-    private CancellationTokenSource? cancelCurrentOperation;
+    private CancellationTokenSource? _cancelCurrentOperation;
 
     public static Func<object, string> GameVersionGroupKeySelector { get; } =
         item => (item as GameVersionViewModel)?.Channel ?? string.Empty;
@@ -186,7 +186,7 @@ public partial class HomeTabViewModel : ViewModelBase
     [RelayCommand]
     public void CancelCurrentMainButtonAction()
     {
-        cancelCurrentOperation?.Cancel();
+        _cancelCurrentOperation?.Cancel();
     }
 
     private void ReactToPropertyChanges(object? sender, PropertyChangedEventArgs? e)
@@ -346,7 +346,7 @@ public partial class HomeTabViewModel : ViewModelBase
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
         MainButtonTooltip = "Cancel installation";
-        cancelCurrentOperation = new CancellationTokenSource();
+        _cancelCurrentOperation = new CancellationTokenSource();
 
         Log("Creating install plan");
             
@@ -365,7 +365,7 @@ public partial class HomeTabViewModel : ViewModelBase
         }
         finally
         {
-            cancelCurrentOperation = null;
+            _cancelCurrentOperation = null;
             await FlushPendingLogWrites();
             IsProgressVisible = false;
             _ksp2InstallService.TryLoadKsp2Install();
@@ -399,7 +399,7 @@ public partial class HomeTabViewModel : ViewModelBase
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
         MainButtonTooltip = "Cancel installation";
-        cancelCurrentOperation = new CancellationTokenSource();
+        _cancelCurrentOperation = new CancellationTokenSource();
         
         try
         {
@@ -414,7 +414,7 @@ public partial class HomeTabViewModel : ViewModelBase
         }
         finally
         {
-            cancelCurrentOperation = null;
+            _cancelCurrentOperation = null;
             await FlushPendingLogWrites();
             IsProgressVisible = false;
             _ksp2InstallService.TryLoadKsp2Install();
@@ -436,8 +436,8 @@ public partial class HomeTabViewModel : ViewModelBase
                 Log,
                 UpdateDownloadProgress,
                 UpdateStepsProgress,
-                cancelCurrentOperation!.Token),
-            cancelCurrentOperation!.Token);
+                _cancelCurrentOperation!.Token),
+            _cancelCurrentOperation!.Token);
 
         void UpdateStepsProgress(int current, int max)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -12,11 +9,9 @@ using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Ksp2Redux.Tools.Common;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
 using Ksp2Redux.Tools.Launcher.ViewModels.Shared;
-using MsBox.Avalonia;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Home;
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -1,22 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Ksp2Redux.Tools.Common;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
 using Ksp2Redux.Tools.Launcher.ViewModels.Community;
 using Ksp2Redux.Tools.Launcher.ViewModels.Home;
 using Ksp2Redux.Tools.Launcher.ViewModels.Mods;
 using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
-using MsBox.Avalonia;
 using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels;

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -38,16 +38,16 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IMessageBoxService _messageBoxService;
     private readonly ILogService _log;
 
-    [ObservableProperty] public partial InstallState CurrentInstallState { get; set; }
+    [ObservableProperty] private InstallState _currentInstallState;
 
-    [ObservableProperty] public partial bool IsUpdateDownloading { get; set; }
+    [ObservableProperty] private bool _isUpdateDownloading;
 
     public HomeTabViewModel HomeTab { get; }
     public CommunityTabViewModel CommunityTab { get; }
     public ModsTabViewModel ModsTab { get; }
     public SettingsTabViewModel SettingsTab { get; }
 
-    [ObservableProperty] public partial int CurrentTab { get; set; }
+    [ObservableProperty] private int _currentTab;
 
     public MainWindowViewModel(HomeTabViewModel homeTab, CommunityTabViewModel communityTab, ModsTabViewModel modsTab,
         SettingsTabViewModel settingsTabViewModel, IKsp2InstallService ksp2InstallService,

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
@@ -12,14 +12,14 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
 
     public Guid Id => _entry.Id;
 
-    [ObservableProperty] public partial string Name { get; set; }
-    [ObservableProperty] public partial string ExePath { get; set; }
-    [ObservableProperty] public partial string ReleaseChannel { get; set; }
-    [ObservableProperty] public partial bool IsActive { get; set; }
-    [ObservableProperty] public partial bool LaunchThroughSteam { get; set; }
-    [ObservableProperty] public partial string SteamAppId { get; set; }
-    [ObservableProperty] public partial string LaunchArguments { get; set; }
-    [ObservableProperty] public partial bool DisableGraphicsJobs { get; set; }
+    [ObservableProperty] private string _name;
+    [ObservableProperty] private string _exePath;
+    [ObservableProperty] private string _releaseChannel;
+    [ObservableProperty] private bool _isActive;
+    [ObservableProperty] private bool _launchThroughSteam;
+    [ObservableProperty] private string _steamAppId;
+    [ObservableProperty] private string _launchArguments;
+    [ObservableProperty] private bool _disableGraphicsJobs;
 
     public Ksp2InstallRowViewModel(IKsp2InstallService ksp2InstallService, Ksp2InstallEntry entry, bool isActive)
     {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -33,9 +33,9 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     public ObservableCollection<string> ValidChannels { get; } = [];
 
-    [ObservableProperty] public partial Ksp2InstallRowViewModel? SelectedInstall { get; set; }
-    [ObservableProperty] public partial bool HasSelectedInstall { get; private set; }
-    [ObservableProperty] public partial bool CanRemoveSelectedInstall { get; private set; }
+    [ObservableProperty] private Ksp2InstallRowViewModel? _selectedInstall;
+    [ObservableProperty] private bool _hasSelectedInstall;
+    [ObservableProperty] private bool _canRemoveSelectedInstall;
 
     public string LauncherVersion => _assemblyService.GetVersion()?.ToString(4) ?? "?";
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -9,10 +9,8 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Ksp2Redux.Tools.Common;
 using Ksp2Redux.Tools.Launcher.Services;
 using Ksp2Redux.Tools.Launcher.ViewModels.Home;
-using MsBox.Avalonia;
 using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Settings;

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Shared/NewsItemViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Shared/NewsItemViewModel.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Threading.Tasks;
-using Avalonia.Media.Imaging;
-using CommunityToolkit.Mvvm.ComponentModel;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
 

--- a/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
-using Avalonia.Platform.Storage;
-using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.ViewModels.Community;
 
 namespace Ksp2Redux.Tools.Launcher.Views;

--- a/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.ViewModels.Community;
@@ -12,11 +13,7 @@ public partial class CommunityTabView : UserControl
 {
     public CommunityTabViewModel ViewModel => (CommunityTabViewModel)DataContext!;
 
-    public CommunityTabView()
-    {
-        InitializeComponent();
-        Html.BaseStylesheet = App.NewsStylesheet;
-    }
+    public CommunityTabView() => AvaloniaXamlLoader.Load(this);
 
     private void LaunchUri(Uri uri)
     {

--- a/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels.Home;
 using System.ComponentModel;
 
@@ -9,10 +10,15 @@ namespace Ksp2Redux.Tools.Launcher.Views;
 public partial class HomeTabView : UserControl
 {
     private HomeTabViewModel? Model => DataContext as HomeTabViewModel;
+    private Button? LaunchButtonControl => this.FindControl<Button>("LaunchButton");
+    private Button? UpdateButtonControl => this.FindControl<Button>("UpdateButton");
+    private Button? CancelButtonControl => this.FindControl<Button>("CancelButton");
+    private Button? InstallButtonControl => this.FindControl<Button>("InstallButton");
+    private TextBox? InstallLogTextBoxControl => this.FindControl<TextBox>("InstallLogTextBox");
 
     public HomeTabView()
     {
-        InitializeComponent();
+        AvaloniaXamlLoader.Load(this);
         Loaded += RefreshAll;
     }
 
@@ -36,23 +42,31 @@ public partial class HomeTabView : UserControl
 
     private void ShowButton(HomeTabViewModel.MainButtonState which)
     {
-        LaunchButton.IsVisible = false;
-        UpdateButton.IsVisible = false;
-        CancelButton.IsVisible = false;
-        InstallButton.IsVisible = false;
+        if (LaunchButtonControl is not { } launchButton ||
+            UpdateButtonControl is not { } updateButton ||
+            CancelButtonControl is not { } cancelButton ||
+            InstallButtonControl is not { } installButton)
+        {
+            return;
+        }
+
+        launchButton.IsVisible = false;
+        updateButton.IsVisible = false;
+        cancelButton.IsVisible = false;
+        installButton.IsVisible = false;
         switch (which)
         {
             case HomeTabViewModel.MainButtonState.Launch:
-                LaunchButton.IsVisible = true;
+                launchButton.IsVisible = true;
                 break;
             case HomeTabViewModel.MainButtonState.Install:
-                InstallButton.IsVisible = true;
+                installButton.IsVisible = true;
                 break;
             case HomeTabViewModel.MainButtonState.Update:
-                UpdateButton.IsVisible = true;
+                updateButton.IsVisible = true;
                 break;
             case HomeTabViewModel.MainButtonState.Cancel:
-                CancelButton.IsVisible = true;
+                cancelButton.IsVisible = true;
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(which), which, null);
@@ -67,7 +81,8 @@ public partial class HomeTabView : UserControl
 
     private void InstallLogTextBox_OnTextChanged(object? sender, TextChangedEventArgs e)
     {
-        var lastLineIndex = Math.Max(0, InstallLogTextBox.GetLineCount() - 1);
-        InstallLogTextBox.ScrollToLine(lastLineIndex);
+        if (InstallLogTextBoxControl is not { } installLogTextBox) return;
+        var lastLineIndex = Math.Max(0, installLogTextBox.GetLineCount() - 1);
+        installLogTextBox.ScrollToLine(lastLineIndex);
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
 using Avalonia.Platform;
 
 namespace Ksp2Redux.Tools.Launcher.Views;
@@ -11,7 +12,7 @@ public partial class MainWindow : Window
 {
     public MainWindow()
     {
-        InitializeComponent();
+        AvaloniaXamlLoader.Load(this);
         Opened += (_, _) =>
         {
             DisableWindowResize();

--- a/Ksp2Redux.Tools.Launcher/Views/ModsTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/ModsTabView.axaml.cs
@@ -6,8 +6,5 @@ namespace Ksp2Redux.Tools.Launcher.Views;
 
 public partial class ModsTabView : UserControl
 {
-    public ModsTabView()
-    {
-        InitializeComponent();
-    }
+    public ModsTabView() => AvaloniaXamlLoader.Load(this);
 }

--- a/Ksp2Redux.Tools.Launcher/Views/ModsTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/ModsTabView.axaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Ksp2Redux.Tools.Launcher.Views;

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
@@ -45,14 +45,14 @@
 				<TextBox Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch"
 				         IsVisible="{Binding HasSelectedInstall}"
 				         Text="{Binding SelectedInstall.Name, Mode=TwoWay}"
-				         Watermark="Name" />
+				         PlaceholderText="Name" />
 
 				<TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}">Install path</TextBlock>
 				<TextBox Grid.Row="3" Grid.Column="1" HorizontalAlignment="Stretch"
 				         IsVisible="{Binding HasSelectedInstall}"
 				         Text="{Binding SelectedInstall.ExePath, Mode=TwoWay}"
-				         Watermark="C:\Steam\SteamGames\KSP2\KSP2_x64.exe"
+				         PlaceholderText="C:\Steam\SteamGames\KSP2\KSP2_x64.exe"
 				         FontFamily="{StaticResource JetBrainsMonoLight}" FontSize="11" />
 
 				<TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"
@@ -75,7 +75,7 @@
 				           ToolTip.Tip="Override to launch a Steam 'Add a Non-Steam Game' shortcut for KSP2. Leave as 954850 for the normal Steam release.">Steam app id</TextBlock>
 				<TextBox Grid.Row="6" Grid.Column="1" HorizontalAlignment="Stretch"
 				         IsVisible="{Binding HasSelectedInstall}"
-				         Watermark="954850"
+				         PlaceholderText="954850"
 				         Text="{Binding SelectedInstall.SteamAppId, Mode=TwoWay}"
 				         IsEnabled="{Binding SelectedInstall.LaunchThroughSteam}" />
 

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
 
 namespace Ksp2Redux.Tools.Launcher.Views;
@@ -8,10 +9,7 @@ public partial class SettingsTabView : UserControl
 {
     private SettingsTabViewModel Model => (DataContext as SettingsTabViewModel)!;
 
-    public SettingsTabView()
-    {
-        InitializeComponent();
-    }
+    public SettingsTabView() => AvaloniaXamlLoader.Load(this);
 
     private async void UninstallReduxClick(object? sender, RoutedEventArgs e)
     {

--- a/Ksp2Redux.Tools.Launcher/Views/Shared/NewsCollectionView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/Shared/NewsCollectionView.axaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Ksp2Redux.Tools.Launcher.Views.Shared;

--- a/Ksp2Redux.Tools.Launcher/Views/Shared/NewsCollectionView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/Shared/NewsCollectionView.axaml.cs
@@ -6,8 +6,5 @@ namespace Ksp2Redux.Tools.Launcher.Views.Shared;
 
 public partial class NewsCollectionView : UserControl
 {
-    public NewsCollectionView()
-    {
-        InitializeComponent();
-    }
+    public NewsCollectionView() => AvaloniaXamlLoader.Load(this);
 }

--- a/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
@@ -3,7 +3,6 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels;
 using Ksp2Redux.Tools.Launcher.ViewModels.Shared;
-using Ksp2Redux.Tools.Launcher.Views;
 
 namespace Ksp2Redux.Tools.Launcher.Views.Shared;
 

--- a/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
@@ -1,8 +1,9 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
-using Ksp2Redux.Tools.Launcher.Models;
+using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels;
 using Ksp2Redux.Tools.Launcher.ViewModels.Shared;
+using Ksp2Redux.Tools.Launcher.Views;
 
 namespace Ksp2Redux.Tools.Launcher.Views.Shared;
 
@@ -15,12 +16,18 @@ public partial class NewsItemView : UserControl
         InitializeComponent();
     }
 
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
     private void NewsPanel_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (TopLevel.GetTopLevel(this) is not MainWindow { DataContext: MainWindowViewModel mainWindowViewModel } mainWindow)
             return;
 
+        var mainTabControl = mainWindow.FindControl<TabControl>("MainTabControl");
+        var communityTab = mainWindow.FindControl<TabItem>("CommunityTab");
+        if (mainTabControl is null || communityTab is null) return;
+
         mainWindowViewModel.CommunityTab.SetSelectedNewsId(ViewModel?.NewsId ?? -1);
-        mainWindow.MainTabControl.SelectedItem = mainWindow.CommunityTab;
+        mainTabControl.SelectedItem = communityTab;
     }
 }

--- a/Ksp2Redux.Tools.PatchApplier/Ksp2Redux.Tools.PatchApplier.csproj
+++ b/Ksp2Redux.Tools.PatchApplier/Ksp2Redux.Tools.PatchApplier.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Ksp2Redux.Tools.PatchGenerator/Ksp2Redux.Tools.PatchGenerator.csproj
+++ b/Ksp2Redux.Tools.PatchGenerator/Ksp2Redux.Tools.PatchGenerator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Ksp2Redux.Tools.Uploader/Ksp2Redux.Tools.Uploader.csproj
+++ b/Ksp2Redux.Tools.Uploader/Ksp2Redux.Tools.Uploader.csproj
@@ -4,12 +4,12 @@
         <OutputType>Exe</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Octokit" Version="14.0.0" />
-      <PackageReference Include="Tomlyn" Version="0.20.0" />
+      <PackageReference Include="Tomlyn" Version="2.6.0" />
     </ItemGroup>
 
 </Project>

--- a/Ksp2Redux.Tools.Uploader/Program.cs
+++ b/Ksp2Redux.Tools.Uploader/Program.cs
@@ -10,10 +10,16 @@ using Tomlyn;
 
 var manifest = args[0];
 
-var uploadManifest = Toml.ToModel<UploadManifest>(File.ReadAllText(manifest), manifest, new TomlModelOptions
+var uploadManifest = TomlSerializer.Deserialize<UploadManifest>(File.ReadAllText(manifest), new TomlSerializerOptions
 {
-    ConvertPropertyName = x => x,
+    SourceName = manifest
 });
+
+if (uploadManifest == null)
+{
+    Console.WriteLine("Failed to parse manifest");
+    return;
+}
 
 var repoSplit = uploadManifest.Repository.Split('/');
 var repoOwner = repoSplit[0];
@@ -116,6 +122,12 @@ var feedFile = existingFeed[0]!;
 var feedSha = feedFile.Sha;
 
 var feedJson = JsonSerializer.Deserialize<JsonManifest>(feedFile.Content);
+
+if (feedJson == null)
+{
+    Console.WriteLine("Failed to parse feed");
+    return;
+}
 
 feedJson.Patches = patchesToPrepend.Concat(feedJson.Patches).ToArray();
 feedJson.GeneratedAt = DateTime.UtcNow;

--- a/Ksp2Redux.Tools.Uploader/Program.cs
+++ b/Ksp2Redux.Tools.Uploader/Program.cs
@@ -1,9 +1,7 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Ksp2Redux.Tools.Uploader;
 using Octokit;
 using Tomlyn;

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Ports the updater over to .NET 10 and refreshes the main dependencies.

Most of this is project/CI/package cleanup, plus a few small launcher fixes needed after the Avalonia and toolkit updates after the update.

- Ported the updater projects to .NET 10
- Added `global.json` pinned to the .NET 10 SDK line
- Updated CI/release workflows to use .NET 10
- Updated NuGet packages to current stable versions where possible
- Swapped the launcher view models away from partial observable properties so they compile cleanly. Rider did not like how this was done after targeting .NET 10 and updating packages.
- Fixed Avalonia code-behind issues around `InitializeComponent` and named controls
- Updated the Tomlyn usage for the newer API
- Replaced deprecated Avalonia `Watermark` usage with `PlaceholderText`
- Kept the existing publish behavior for launcher and installer builds
- Optimized imports across all solutions

Things seems to work as expected here and everything compiles nicly.