### PR TITLE
window border gap fix

### DIFF
--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
@@ -89,7 +89,7 @@
     </Window.Styles>
 
     <Border BorderBrush="#dc1501" BorderThickness="2" CornerRadius="10" VerticalAlignment="Stretch">
-        <Border Margin="2" CornerRadius="8" ClipToBounds="True">
+        <Border Background="#ff000000" CornerRadius="8" ClipToBounds="True">
             <Grid RowDefinitions="Auto,*">
                 <Border Grid.RowSpan="2">
                     <Border.Background>

--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
@@ -49,6 +49,11 @@ public partial class MainWindow : Window
 
         const int GWL_STYLE = -16;
         const int WS_THICKFRAME = 0x00040000;
+        const uint SWP_NOMOVE = 0x0002;
+        const uint SWP_NOSIZE = 0x0001;
+        const uint SWP_NOZORDER = 0x0004;
+        const uint SWP_NOACTIVATE = 0x0010;
+        const uint SWP_FRAMECHANGED = 0x0020;
 
         nint hwnd = handle.Handle;
         int style = GetWindowLong(hwnd, GWL_STYLE);
@@ -57,6 +62,11 @@ public partial class MainWindow : Window
         style &= ~WS_THICKFRAME;
 
         SetWindowLong(hwnd, GWL_STYLE, style);
+
+        // SetWindowLong alone doesn't make Windows recompute the frame; without this,
+        // it can keep using metrics cached under the old WS_THICKFRAME style.
+        SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
     }
 
     private void SetCustomWndProc()
@@ -122,6 +132,9 @@ public partial class MainWindow : Window
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern int SetWindowLong(nint hWnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern nint GetWindowLongPtr(nint hWnd, int nIndex);


### PR DESCRIPTION
Munix posted a screenshot in Discord showing a weird gap between the window border and the background, guessed it was from the .NET 10 upgrade. Dug into it, found two separate things stacked on top of each other.

The bigger one: the inner Border that holds the background image had a `Margin="2"` on it, on top of the automatic inset Border already gives its content for BorderThickness. So the content was getting pushed in twice, leaving a visible transparent band all the way around between the red frame and the background. That's almost certainly what showed up in the screenshot.

After fixing that there was still a much smaller, 1px gap left on the left and right edges only (not top or bottom). Tracked that down by screenshotting the running window and moving it around the screen: that specific pixel changed color to match whatever was behind the window each time, which means it was genuinely transparent and letting the real desktop bleed through rather than being some anti-aliasing artifact. The window uses real per-pixel transparency and that inner Border never had a background of its own, so wherever nothing else happened to paint, you'd see straight through it. Gave it an opaque black background and reran the same test, the pixel is now solid and stable no matter where the window sits.

Second commit is a smaller thing I noticed while poking around the window's Win32 code: `DisableWindowResize()` strips `WS_THICKFRAME` via `SetWindowLong` but never tells Windows to recompute the frame afterwards, which it doesn't do on its own. Added the `SetWindowPos`/`SWP_FRAMECHANGED` call for that. Turned out not to be related to the actual bug (the background fix above was), but it's a real gap in its own right so I left it in.

Should be fixex now and looks good:

<img width="1020" height="750" alt="image" src="https://github.com/user-attachments/assets/b0c78dd2-7e4d-462f-9198-ca25659a29c6" />

<img width="1033" height="726" alt="image" src="https://github.com/user-attachments/assets/b12b5fd5-a65b-49d5-bc38-2b18f9682b04" />
