### PR TITLE
UI overhaul, NuGet bumps & v0.0.9.0

### DIFF
--- a/Ksp2Redux.Tools.Common/Ksp2Redux.Tools.Common.csproj
+++ b/Ksp2Redux.Tools.Common/Ksp2Redux.Tools.Common.csproj
@@ -14,7 +14,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+      <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2Redux.Tools.Launcher.Test.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Headless.NUnit" Version="12.0.4" />
+        <PackageReference Include="Avalonia.Headless.NUnit" Version="12.0.5" />
         <PackageReference Include="coverlet.collector" Version="10.0.1"/>
         <PackageReference Include="EnvironmentAbstractions.BannedApiAnalyzer" Version="5.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="EnvironmentAbstractions.TestHelpers" Version="5.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit.Analyzers" Version="4.14.0"/>

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -24,12 +24,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.4" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+        <PackageReference Include="Avalonia" Version="12.0.5" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
         <PackageReference Include="Avalonia.HtmlRenderer" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
-        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
         <PackageReference Include="CodeHollow.FeedReader" Version="1.2.6" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
@@ -39,7 +39,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -48,7 +48,7 @@
         <PackageReference Include="Mono.Cecil" Version="0.11.6" />
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="Testably.Abstractions" Version="10.2.0" />
-        <PackageReference Include="Tomlyn" Version="2.6.0" />
+        <PackageReference Include="Tomlyn" Version="2.10.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.0.8.1</Version>
+        <Version>0.0.9.0</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Ksp2Redux.Tools.Launcher.Services;
+﻿using CommunityToolkit.Mvvm.Input;
+using Ksp2Redux.Tools.Launcher.Services;
 using Ksp2Redux.Tools.Launcher.ViewModels.Shared;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Community;
@@ -29,5 +30,11 @@ public partial class CommunityTabViewModel(INewsItemCollectionService newsCollec
     public void SetSelectedNewsId(int newsId)
     {
         SelectedNewsId = newsId;
+    }
+
+    [RelayCommand]
+    private void DeselectNews()
+    {
+        SelectedNewsId = -1;
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml
@@ -52,7 +52,7 @@
         </Style>
     </UserControl.Styles>
 
-    <Grid ColumnDefinitions="Auto,*" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+    <Grid ColumnDefinitions="260,*" Margin="6,0,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
         <StackPanel Spacing="8">
             <Grid RowDefinitions="Auto,*" ColumnDefinitions="Auto">
                 <shared:NewsCollectionView Grid.RowSpan="2" DataContext="{Binding NewsCollectionViewModel}"/>
@@ -95,7 +95,7 @@
                 </Button>
             </StackPanel>
         </StackPanel>
-        <Border Grid.Column="1" Margin="12, 8, 12, 0" BorderThickness="2" BorderBrush="#803E3E3E" Background="#2D2D2D" CornerRadius="12" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" IsVisible="{Binding NewsVisible}">
+        <Border Grid.Column="1" Margin="12, 8, 4, 0" BorderThickness="2" BorderBrush="#803E3E3E" Background="#2D2D2D" CornerRadius="12" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" IsVisible="{Binding NewsVisible}">
             <DockPanel Name="NewsDock" Margin="8" DataContext="{Binding SelectedNews}" LastChildFill="True">
                 <Grid Name="NewsHeader" DockPanel.Dock="Top" ColumnDefinitions="*, Auto">
                     <TextBlock Grid.Column="0" Margin="0, 0, 4, 4" FontSize="12" FontFamily="{StaticResource JetBrainsMonoRegular}"
@@ -113,9 +113,11 @@
                         </Canvas>
                     </Button>
                 </Grid>
-                <HtmlPanel Name="Html"
-                           BaseStylesheet="{x:Static launcher:App.NewsStylesheet}"
-                           Text="{Binding Content}"/>
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <HtmlPanel Name="Html"
+                               BaseStylesheet="{x:Static launcher:App.NewsStylesheet}"
+                               Text="{Binding Content}"/>
+                </ScrollViewer>
             </DockPanel>
         </Border>
     </Grid>

--- a/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml
@@ -133,11 +133,11 @@
 
 	</UserControl.Styles>
 
-    <Grid RowDefinitions="Auto,*,Auto,Auto" ColumnDefinitions="Auto,*">
+    <Grid RowDefinitions="Auto,*,Auto,Auto" ColumnDefinitions="260,*" Margin="6,0,0,0">
         <shared:NewsCollectionView Grid.RowSpan="2" DataContext="{Binding NewsCollectionViewModel}"/>
 
-		<StackPanel Grid.Row="2" Grid.Column="0" Orientation="Vertical" Margin="8,20,8,10">
-			<ComboBox Name="InstallSelector" Width="250"
+		<StackPanel Grid.Row="2" Grid.Column="0" Orientation="Vertical" Margin="0,20,0,10">
+			<ComboBox Name="InstallSelector"
 			          FontFamily="{StaticResource JetBrainsMonoRegular}"
 			          HorizontalAlignment="Stretch" Margin="0,0,0,6"
 			          Background="#12FFFFFF" CornerRadius="6" BorderBrush="Transparent" FontSize="11"
@@ -150,7 +150,7 @@
 					</DataTemplate>
 				</ComboBox.ItemTemplate>
 			</ComboBox>
-			<Grid Width="250" HorizontalAlignment="Left" ColumnDefinitions="*,Auto">
+			<Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,Auto">
 				<controls:GroupedComboBox
 					Grid.Column="0"
 					Name="VersionSelector"
@@ -183,36 +183,36 @@
 		<Button Classes="main-button" Grid.Row="3" Grid.Column="0" IsVisible="True" Name="InstallButton" Command="{Binding InstallRedux}"
 				IsEnabled="{Binding MainButtonEnabled}"
 				ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
-			<Canvas Width="240" Height="70">
-				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-install.png" Canvas.Left="0" Canvas.Top="0" Width="240" />
-				<Border Classes="main-button-tint" Width="240" Height="70" CornerRadius="8" />
+			<Canvas Width="260" Height="76">
+				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-install.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
+				<Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="8" />
 				<TextBlock FontFamily="{StaticResource LedCounter7}">INSTALL</TextBlock>
 			</Canvas>
 		</Button>
 		<Button Classes="main-button" Grid.Row="3" Grid.Column="0" IsVisible="False" Name="UpdateButton" Command="{Binding UpdateRedux}"
 				IsEnabled="{Binding MainButtonEnabled}"
 				ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
-			<Canvas Width="240" Height="70">
-				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-update.png" Canvas.Left="0" Canvas.Top="0" Width="240" />
-				<Border Classes="main-button-tint" Width="240" Height="70" CornerRadius="8" />
+			<Canvas Width="260" Height="76">
+				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-update.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
+				<Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="8" />
 				<TextBlock FontFamily="{StaticResource LedCounter7}">UPDATE</TextBlock>
 			</Canvas>
 		</Button>
 		<Button Classes="main-button" Grid.Row="3" Grid.Column="0" IsVisible="False" Name="CancelButton" ClickMode="Press" Command="{Binding CancelCurrentMainButtonAction}"
 				IsEnabled="{Binding MainButtonEnabled}"
 				ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
-			<Canvas Width="240" Height="70">
-				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-cancel.png" Canvas.Left="0" Canvas.Top="0" Width="240" />
-				<Border Classes="main-button-tint" Width="240" Height="70" CornerRadius="8" />
+			<Canvas Width="260" Height="76">
+				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-cancel.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
+				<Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="8" />
 				<TextBlock FontFamily="{StaticResource LedCounter7}">CANCEL</TextBlock>
 			</Canvas>
 		</Button>
 		<Button Classes="main-button" Grid.Row="3" Grid.Column="0" IsVisible="False" Name="LaunchButton" Command="{Binding LaunchGame}"
 				IsEnabled="{Binding MainButtonEnabled}"
 				ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
-			<Canvas Width="240" Height="70">
-				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-launch.png" Canvas.Left="0" Canvas.Top="0" Width="240" />
-				<Border Classes="main-button-tint" Width="240" Height="70" CornerRadius="8" />
+			<Canvas Width="260" Height="76">
+				<Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-launch.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
+				<Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="8" />
 				<TextBlock FontFamily="{StaticResource LedCounter7}">LAUNCH</TextBlock>
 			</Canvas>
 		</Button>

--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
@@ -21,6 +21,10 @@
         <vm:MainWindowViewModel />
     </Design.DataContext>
 
+    <Window.KeyBindings>
+        <KeyBinding Gesture="Escape" Command="{Binding CommunityTab.DeselectNewsCommand}" />
+    </Window.KeyBindings>
+
     <!-- ReSharper disable Xaml.RedundantResource -->
     <Window.Resources>
         <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="#df1501" />

--- a/Ksp2Redux.Tools.Launcher/Views/ModsTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/ModsTabView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -6,5 +6,19 @@
              x:DataType="mods:ModsTabViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Ksp2Redux.Tools.Launcher.Views.ModsTabView">
-    Coming soon... :3
+    <Border HorizontalAlignment="Center" VerticalAlignment="Center"
+            Background="#A02D2D2D" CornerRadius="12" Padding="40,28">
+        <StackPanel Spacing="8">
+            <TextBlock Text="COMING SOON"
+                       FontFamily="{StaticResource JetBrainsMonoLight}"
+                       FontSize="32"
+                       Foreground="White"
+                       HorizontalAlignment="Center" />
+            <TextBlock Text="Mod support is on the roadmap :3"
+                       FontFamily="{StaticResource JetBrainsMonoRegular}"
+                       FontSize="14"
+                       Foreground="#CCCCCC"
+                       HorizontalAlignment="Center" />
+        </StackPanel>
+    </Border>
 </UserControl>

--- a/Ksp2Redux.Tools.Launcher/Views/Shared/NewsCollectionView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/Shared/NewsCollectionView.axaml
@@ -15,7 +15,7 @@
                 ClipToBounds="True"
                 Margin="0,0,0,0"
                 VerticalAlignment="Stretch">
-            <ScrollViewer Width="240" Height="340"
+            <ScrollViewer Width="260" Height="340"
                           ClipToBounds="True"
                           VerticalScrollBarVisibility="Auto">
                 <ItemsControl Margin="20,16, 20,16" ItemsSource="{Binding NewsCollection}"

--- a/Ksp2Redux.Tools.Uploader/Ksp2Redux.Tools.Uploader.csproj
+++ b/Ksp2Redux.Tools.Uploader/Ksp2Redux.Tools.Uploader.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="Octokit" Version="14.0.0" />
-      <PackageReference Include="Tomlyn" Version="2.6.0" />
+      <PackageReference Include="Tomlyn" Version="2.10.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This is a follow-up on the little window-chrome fixes from before, but broader: went through Home, Community, and Mods together since fixing one kept surfacing the next thing that didn't match.

Home's left column (news box, both dropdowns, install button) had three different width rules fighting each other (240 vs 250, plus an extra margin only some of them had), so nothing lined up with each other or with the logo above it. Gave the whole column one real width instead and let everything stretch to fill it. The install/update button art got scaled up proportionally to match rather than sitting centered and narrower.

Turned out Community had the exact same news column but never got the same left-alignment fix, so it sat 6px off from Home and visibly jumped every time you switched tabs. Same fix applied there, plus tightened up the article panel's right margin which was noticeably more generous than the left side.

The bigger Community fix: the article view never actually had a real scrollbar. HtmlPanel tracks a scroll offset internally but doesn't draw anything for it, so long articles just had silent, invisible scrolling, completely different from the news list right next to it. Wrapped it in an actual ScrollViewer and now it behaves and looks the same as everything else.

Also added Escape to deselect a news post. First attempt put the KeyBinding on the view itself and it just didn't fire, took a bit to figure out why: selecting a post happens entirely through code-behind, so nothing in that view ever gets keyboard focus, and the KeyDown event's route never touches it. Moved the binding up to the Window instead, which is always in that path regardless of focus.

Mods tab was just bare unstyled text sitting top-left, and the subtitle was nearly unreadable against the brighter parts of the background art. Centered it and put it on a small card so it's legible no matter what's behind it.

Also updated NuGet packages: Avalonia (12.0.4 → 12.0.5 across the board), Avalonia.Headless.NUnit, Microsoft.NET.Test.Sdk, Tomlyn (2.6.0 → 2.10.1), and Microsoft.CodeAnalysis.BannedApiAnalyzers (3.3.4 → 5.6.0, a major jump). Didn't just trust a green build for these since a couple land right on top of behavior this PR depends on:
- Redid the Tomlyn `required`-property scratch test against 2.10.1, same result as before (still purely compile-time, delete-only manifests still work).
- Regenerated and applied a `.patch` file end to end through Common, unaffected.
- Re-ran the full visual check against Avalonia 12.0.5: window border fix, column alignment, button widths, Escape-to-deselect, and the HtmlPanel/ScrollViewer fix all still hold.
- Clean rebuild shows no new warnings from the BannedApiAnalyzers major bump.

Since all these changes in this and prevous PR I propose a version bump to 0.0.9.0 