### PR TITLE
Reliability/patch pipeline hardening

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DownloadTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DownloadTest.cs
@@ -124,7 +124,7 @@ public class DownloadTest
 
         ReleasePatch patch1Rollup = new()
         {
-            ChecksumSha256 = Convert.ToBase64String(SHA256.HashData(patch1RollupZipBytes)),
+            ChecksumSha256 = Convert.ToHexString(SHA256.HashData(patch1RollupZipBytes)),
             ReleasedAt = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Requires = new PatchRequirement { Version = null },
             Size = 10,

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/FeedRefreshFailureTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/FeedRefreshFailureTest.cs
@@ -1,0 +1,88 @@
+using System.Net.Http;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class FeedRefreshFailureTest
+{
+    private const string DefaultChannel = "beta";
+    private const string OtherChannel = "stable";
+
+    [AvaloniaTest]
+    public async Task RefreshFeeds_ManifestFetchThrows_ShowsWarningBannerUntilNextSuccessfulRefresh()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        ReleaseManifest MakeManifest(string channel) => new()
+        {
+            Channel = channel,
+            GeneratedAt = new DateTime(2020, 1, 4),
+            Patches = [],
+            SchemaVersion = 1,
+        };
+
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel))))
+            .ReturnsAsync(MakeManifest(DefaultChannel));
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel) == false)))
+            .ReturnsAsync(MakeManifest(OtherChannel));
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+        Assert.That(homeTabViewModel.FeedRefreshFailed, Is.False);
+
+        var warningText = window.GetVisualDescendants().OfType<Avalonia.Controls.TextBlock>()
+            .FirstOrDefault(t => t.Name == "FeedRefreshWarning");
+        Assert.That(warningText, Is.Not.Null);
+        Assert.That(warningText!.IsVisible, Is.False);
+
+        // Act - simulate the feed fetch failing on the next refresh (e.g. network drop)
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.IsAny<FeedInfo>()))
+            .ThrowsAsync(new HttpRequestException("network unreachable"));
+
+        await homeTabViewModel.RefreshFeedsCommand.ExecuteAsync(null);
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - banner shows while the feed is failing
+        Assert.That(homeTabViewModel.FeedRefreshFailed, Is.True);
+        Assert.That(warningText.IsVisible, Is.True);
+
+        // Act - the feed recovers on the following refresh
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel))))
+            .ReturnsAsync(MakeManifest(DefaultChannel));
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel) == false)))
+            .ReturnsAsync(MakeManifest(OtherChannel));
+
+        await homeTabViewModel.RefreshFeedsCommand.ExecuteAsync(null);
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - banner clears once refreshes succeed again
+        Assert.That(homeTabViewModel.FeedRefreshFailed, Is.False);
+        Assert.That(warningText.IsVisible, Is.False);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/MainButtonTooltipTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/MainButtonTooltipTest.cs
@@ -1,0 +1,89 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class MainButtonTooltipTest
+{
+    [AvaloniaTest]
+    public async Task MainButton_NoInstallDetected_ShowsAnExplanatoryTooltipBoundOnTheActualButton()
+    {
+        // Arrange - no install registered at all, so the main button stays on its Launch-shaped
+        // disabled default. This is the state a reviewer flagged as having lost its "why is this
+        // disabled" tooltip when it was previously (over-)removed for repeating the button's label.
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+        var installButton = window.GetVisualDescendants().OfType<Button>().Single(b => b.Name == "InstallButton");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTabViewModel.MainButtonEnabled, Is.False);
+            Assert.That(homeTabViewModel.MainButtonTooltip, Does.Contain("not detected"));
+            Assert.That(ToolTip.GetTip(installButton), Is.EqualTo(homeTabViewModel.MainButtonTooltip),
+                "The button's actual ToolTip.Tip must be bound to MainButtonTooltip, not just set on the view model.");
+            Assert.That(ToolTip.GetShowOnDisabled(installButton), Is.True,
+                "A tooltip that only matters while disabled needs ShowOnDisabled, or it will never be seen.");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task MainButton_ReadyToLaunch_HasNoTooltip()
+    {
+        // Arrange - a normal, enabled state shouldn't show a tooltip that just repeats the button's
+        // own label (the original, narrower complaint that led to the tooltip being removed entirely).
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        // No newer release than what's already installed, so the version dropdown defaults to the
+        // synthetic "installed" entry and the button lands on its enabled Launch state.
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.IsAny<FeedInfo>()))
+            .ReturnsAsync((FeedInfo f) => new ReleaseManifest
+            {
+                Channel = f.Filename.Split('-', '.')[1],
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [],
+                SchemaVersion = 1,
+            });
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTabViewModel.MainButtonEnabled, Is.True);
+            Assert.That(homeTabViewModel.MainButtonTooltip, Is.Null.Or.Empty);
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SilentFailureVisibilityTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SilentFailureVisibilityTest.cs
@@ -1,0 +1,47 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class SilentFailureVisibilityTest
+{
+    [AvaloniaTest]
+    public async Task UpdateLauncher_ThrowingUnexpectedly_ShowsFailureDialogInsteadOfFailingSilently()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        // Act
+        await homeTabViewModel.UpdateLauncher();
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - the failure surfaces as a dialog, not just a log line
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+            "Update Failed!",
+            It.Is<string>(s => s.Contains("boom")),
+            It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/TestAppBuilder.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/TestAppBuilder.cs
@@ -26,6 +26,7 @@ public static class TestAppBuilder
     public static Mock<IUpdateService> UpdateService { get; private set; } = null!;
     public static Mock<IMessageBoxService> MessageBoxService { get; private set; } = null!;
     public static Mock<IOperatingSystemService> OperatingSystemService { get; private set; } = null!;
+    public static Mock<IDiskSpaceService> DiskSpaceService { get; private set; } = null!;
 
     public static IServiceProvider ServiceProvider { get; set; } = null!;
 
@@ -56,6 +57,8 @@ public static class TestAppBuilder
         OperatingSystemService = new();
         // Fully mocked for now, but could be tested if Http, Process and RuntimeInfo are separated in separated mockable interfaces
         UpdateService = new();
+        DiskSpaceService = new();
+        DiskSpaceService.Setup(d => d.GetAvailableFreeSpace(It.IsAny<string>())).Returns(long.MaxValue);
 
         ServiceCollection serviceCollection = new();
         serviceCollection.AddSingleton<MainWindowViewModel>();
@@ -82,7 +85,8 @@ public static class TestAppBuilder
         serviceCollection.AddSingleton(UpdateService.Object);
         serviceCollection.AddSingleton<IKsp2DetectorService, Ksp2DetectorService>(); 
         serviceCollection.AddSingleton(MessageBoxService.Object); 
-        serviceCollection.AddSingleton(OperatingSystemService.Object); 
+        serviceCollection.AddSingleton(OperatingSystemService.Object);
+        serviceCollection.AddSingleton(DiskSpaceService.Object);
         ServiceProvider = serviceCollection.BuildServiceProvider();
     }
 }

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionSelectionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionSelectionTest.cs
@@ -1,0 +1,95 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Controls;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class VersionSelectionTest
+{
+    private const string DefaultChannel = "beta";
+    private const string OtherChannel = "stable";
+
+    [AvaloniaTest]
+    public void ChangingAnInstallSetting_DoesNotResetTheSelectedVersion()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        ReleasePatch patch = new()
+        {
+            ChecksumSha256 = "0",
+            ReleasedAt = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Requires = new PatchRequirement { Version = null },
+            Size = 10,
+            Url = "https://github.com/patch1Rollup.patch",
+            Version = "0.2.3.1.1234",
+        };
+
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel))))
+            .ReturnsAsync(new ReleaseManifest
+            {
+                Channel = DefaultChannel,
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [patch],
+                SchemaVersion = 1
+            });
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel) == false)))
+            .ReturnsAsync((FeedInfo f) => new ReleaseManifest
+            {
+                Channel = f.Filename.Split('-', '.')[1],
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [],
+                SchemaVersion = 1
+            });
+
+        // Act
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        GroupedComboBox? versionSelectorCombobox = window
+            .GetVisualDescendants()
+            .OfType<GroupedComboBox>()
+            .FirstOrDefault(x => x.Name == "VersionSelector");
+        Assert.That(versionSelectorCombobox, Is.Not.Null);
+
+        var nonDefaultVersion = versionSelectorCombobox.GroupedItems
+            .OfType<GameVersionViewModel>()
+            .Single(g => g.VersionString.Contains("0.2.3.1.1234"));
+        versionSelectorCombobox.SelectedItem = nonDefaultVersion;
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+        Assert.That(homeTabViewModel.SelectedVersion?.VersionString, Does.Contain("0.2.3.1.1234"));
+
+        // Simulate a settings-page change to the active install (e.g. toggling "disable graphics jobs"),
+        // which fires ActiveInstallChanged - this used to silently reset the version dropdown.
+        var ksp2InstallService = TestAppBuilder.ServiceProvider.GetRequiredService<IKsp2InstallService>();
+        var activeEntryId = ksp2InstallService.ActiveEntry!.Id;
+        ksp2InstallService.UpdateInstallDisableGraphicsJobs(activeEntryId, true);
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert
+        Assert.That(homeTabViewModel.SelectedVersion?.VersionString, Does.Contain("0.2.3.1.1234"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceDiskSpaceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceDiskSpaceTest.cs
@@ -1,0 +1,77 @@
+using Ksp2Redux.Tools.Common.Service;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class InstallPlanServiceDiskSpaceTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+
+    private static (InstallPlanService Service, Mock<IDiskSpaceService> DiskSpace, MockFileSystem Fs) MakeService()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+
+        var cacheService = new Mock<ICacheService>();
+        var environmentProvider = new MockEnvironmentProvider();
+        var assemblyService = new Mock<IAssemblyService>();
+        var moduleDefinitionService = new Mock<IModuleDefinitionService>();
+        var zipFileService = new Mock<IZipFileService>();
+        var diskSpace = new Mock<IDiskSpaceService>();
+
+        var service = new InstallPlanService(fs, cacheService.Object, environmentProvider, assemblyService.Object,
+            moduleDefinitionService.Object, zipFileService.Object, diskSpace.Object);
+        return (service, diskSpace, fs);
+    }
+
+    [Test]
+    public void ApplyToFolder_NotEnoughFreeSpace_ThrowsBeforeTouchingAnyStep()
+    {
+        var (service, diskSpace, _) = MakeService();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(InstallDir)).Returns(1024); // basically nothing
+
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, _) => Task.FromResult("unused"), "big patch", downloadSize: 10L * 1024 * 1024 * 1024); // 10 GB
+
+        Assert.That(async () => await service.ApplyToFolder(plan, InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None),
+            Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public async Task ApplyToFolder_EnoughFreeSpace_DoesNotThrowFromSpaceCheck()
+    {
+        var (service, diskSpace, _) = MakeService();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(InstallDir)).Returns(100L * 1024 * 1024 * 1024); // 100 GB
+
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, ct) => Task.FromResult(InstallDir), "small patch", downloadSize: 1024);
+
+        // A missing/invalid patch file will fail later in Ksp2Patch.FromFile - that's fine, it means the
+        // space check itself let it through.
+        Exception? thrown = null;
+        try { await service.ApplyToFolder(plan, InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None); }
+        catch (Exception ex) { thrown = ex; }
+
+        Assert.That(thrown?.Message ?? "", Does.Not.Contain("disk space"));
+    }
+
+    [Test]
+    public async Task ApplyToFolder_DiskSpaceUnknown_SkipsCheckAndProceeds()
+    {
+        var (service, diskSpace, _) = MakeService();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(InstallDir)).Returns((long?)null);
+
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, _) => Task.FromResult("unused"), "big patch", downloadSize: 10L * 1024 * 1024 * 1024);
+
+        // Should not throw due to disk space (unknown => skip check); it'll fail later for other reasons instead.
+        Exception? thrown = null;
+        try { await service.ApplyToFolder(plan, InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None); }
+        catch (Exception ex) { thrown = ex; }
+
+        Assert.That(thrown?.Message ?? "", Does.Not.Contain("disk space"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceRollbackTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceRollbackTest.cs
@@ -1,0 +1,93 @@
+using Ksp2Redux.Tools.Common.Service;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class InstallPlanServiceRollbackTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+    private const string PatchPath = @"C:\downloads\corrupt.patch";
+
+    private static (InstallPlanService Service, Mock<ICacheService> CacheService, MockFileSystem Fs)
+        MakeService(Mock<IZipFileService> zipFileService)
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+        fs.Directory.CreateDirectory(fs.Path.GetDirectoryName(PatchPath)!);
+        fs.File.WriteAllBytes(PatchPath, [0x01]);
+
+        var cacheService = new Mock<ICacheService>();
+        var environmentProvider = new MockEnvironmentProvider();
+        var assemblyService = new Mock<IAssemblyService>();
+        var moduleDefinitionService = new Mock<IModuleDefinitionService>();
+        var diskSpace = new Mock<IDiskSpaceService>();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(It.IsAny<string>())).Returns(long.MaxValue);
+
+        var service = new InstallPlanService(fs, cacheService.Object, environmentProvider, assemblyService.Object,
+            moduleDefinitionService.Object, zipFileService.Object, diskSpace.Object);
+        return (service, cacheService, fs);
+    }
+
+    private static InstallPlan MakeCorruptPatchPlan()
+    {
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, _) => Task.FromResult(PatchPath), "corrupt patch");
+        return plan;
+    }
+
+    [Test]
+    public async Task ApplyToFolder_PatchApplyFailsWithSnapshotAvailable_RollsBackAndThrowsInstallFailedException()
+    {
+        var zipFileService = new Mock<IZipFileService>();
+        zipFileService.Setup(z => z.OpenRead(PatchPath)).Throws(new IOException("archive is corrupt"));
+
+        var (service, cacheService, fs) = MakeService(zipFileService);
+        fs.File.WriteAllBytes(fs.Path.Combine(InstallDir, "uninstall.zip"), [0x00]); // a snapshot exists
+
+        var ex = Assert.ThrowsAsync<InstallFailedException>(async () =>
+            await service.ApplyToFolder(MakeCorruptPatchPlan(), InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None));
+
+        Assert.That(ex!.RolledBack, Is.True);
+        Assert.That(ex.Message, Does.Contain("rolled back"));
+        Assert.That(ex.InnerException, Is.InstanceOf<IOException>());
+        cacheService.Verify(c => c.RecursivelyRestoreCache(InstallDir, true), Times.Once);
+    }
+
+    [Test]
+    public async Task ApplyToFolder_PatchApplyFailsAndRollbackAlsoFails_ThrowsWithBothFailuresDescribed()
+    {
+        var zipFileService = new Mock<IZipFileService>();
+        zipFileService.Setup(z => z.OpenRead(PatchPath)).Throws(new IOException("archive is corrupt"));
+
+        var (service, cacheService, fs) = MakeService(zipFileService);
+        fs.File.WriteAllBytes(fs.Path.Combine(InstallDir, "uninstall.zip"), [0x00]);
+        cacheService.Setup(c => c.RecursivelyRestoreCache(InstallDir, true))
+            .Throws(new IOException("disk full while restoring"));
+
+        var ex = Assert.ThrowsAsync<InstallFailedException>(async () =>
+            await service.ApplyToFolder(MakeCorruptPatchPlan(), InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None));
+
+        Assert.That(ex!.RolledBack, Is.False);
+        Assert.That(ex.Message, Does.Contain("archive is corrupt"));
+        Assert.That(ex.Message, Does.Contain("disk full while restoring"));
+    }
+
+    [Test]
+    public async Task ApplyToFolder_PatchApplyFailsWithNoSnapshot_RethrowsOriginalExceptionUnwrapped()
+    {
+        var zipFileService = new Mock<IZipFileService>();
+        zipFileService.Setup(z => z.OpenRead(PatchPath)).Throws(new IOException("archive is corrupt"));
+
+        var (service, cacheService, _) = MakeService(zipFileService);
+        // No uninstall.zip created - nothing to roll back to yet.
+
+        var ex = Assert.ThrowsAsync<IOException>(async () =>
+            await service.ApplyToFolder(MakeCorruptPatchPlan(), InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None));
+
+        Assert.That(ex!.Message, Is.EqualTo("archive is corrupt"));
+        cacheService.Verify(c => c.RecursivelyRestoreCache(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallServiceTest.cs
@@ -19,9 +19,10 @@ public class Ksp2InstallServiceTest
         fileSystem.SetupGet(fs => fs.Path).Returns(path.Object);
 
         var moduleDef = new Mock<IModuleDefinitionService>();
+        var logService = new Mock<ILogService>();
         var config = new LauncherConfig { StoragePath = "/tmp/cfg.json" };
         cfg.SetupGet(c => c.Config).Returns(config);
-        var svc = new Ksp2InstallService(cfg.Object, fileSystem.Object, moduleDef.Object);
+        var svc = new Ksp2InstallService(cfg.Object, fileSystem.Object, moduleDef.Object, logService.Object);
         return (svc, cfg, config);
     }
 

--- a/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedDownloadPatchTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedDownloadPatchTest.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using System.Security.Cryptography;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class ManifestReleasesFeedDownloadPatchTest
+{
+    private const string DownloadDir = @"C:\downloads";
+
+    private static (ManifestReleasesFeed Feed, Mock<IManifestReleasesFeedProviderService> Provider, MockFileSystem Fs)
+        MakeFeed()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(DownloadDir);
+        var provider = new Mock<IManifestReleasesFeedProviderService>();
+        var log = new Mock<ILogService>();
+        var feedInfo = new FeedInfo { Repository = "KSP2Redux/Redux", Filename = "manifest-beta.json" };
+
+        var feed = new ManifestReleasesFeed(fs, provider.Object, log.Object, DownloadDir, feedInfo);
+        return (feed, provider, fs);
+    }
+
+    private static ReleasePatch MakePatch(byte[] content, string url = "https://example.com/patch.patch")
+    {
+        return new ReleasePatch
+        {
+            Version = "0.2.3.1.1234",
+            Requires = new PatchRequirement { Version = null },
+            Url = url,
+            ChecksumSha256 = Convert.ToHexString(SHA256.HashData(content)),
+            Size = content.Length,
+            ReleasedAt = DateTime.UtcNow,
+        };
+    }
+
+    private static void SetupDownload(Mock<IManifestReleasesFeedProviderService> provider, byte[] content)
+    {
+        provider.Setup(p => p.DownloadPatchAsync(It.IsAny<FeedInfo>(), It.IsAny<ReleasePatch>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                Content = new ByteArrayContent(content) { Headers = { ContentLength = content.Length } },
+                StatusCode = HttpStatusCode.OK,
+            });
+    }
+
+    [Test]
+    public async Task DownloadPatch_ChecksumMatches_ReturnsDownloadedFile()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] content = [1, 2, 3, 4, 5];
+        var patch = MakePatch(content);
+        SetupDownload(provider, content);
+
+        var path = await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None);
+
+        Assert.That(fs.File.Exists(path), Is.True);
+        Assert.That(fs.File.ReadAllBytes(path), Is.EqualTo(content));
+    }
+
+    [Test]
+    public async Task DownloadPatch_ChecksumMismatch_ThrowsAndDeletesCorruptFile()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] content = [1, 2, 3, 4, 5];
+        var patch = MakePatch([9, 9, 9, 9, 9]); // checksum for different bytes than what actually downloads
+        SetupDownload(provider, content);
+
+        Assert.That(async () => await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None),
+            Throws.InvalidOperationException);
+
+        string expectedPath = fs.Path.Combine(DownloadDir, "patch.patch");
+        Assert.That(fs.File.Exists(expectedPath), Is.False);
+    }
+
+    [Test]
+    public async Task DownloadPatch_CachedFileWithWrongHash_RedownloadsInsteadOfTrustingCache()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] goodContent = [1, 2, 3, 4, 5];
+        byte[] staleContent = [9, 9, 9, 9, 9]; // same length as goodContent, but wrong bytes/hash
+        var patch = MakePatch(goodContent);
+
+        string cachedPath = fs.Path.Combine(DownloadDir, "patch.patch");
+        fs.File.WriteAllBytes(cachedPath, staleContent);
+        SetupDownload(provider, goodContent);
+
+        var path = await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None);
+
+        Assert.That(fs.File.ReadAllBytes(path), Is.EqualTo(goodContent));
+        provider.Verify(p => p.DownloadPatchAsync(It.IsAny<FeedInfo>(), It.IsAny<ReleasePatch>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task DownloadPatch_CachedFileMatchesHash_SkipsRedownload()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] content = [1, 2, 3, 4, 5];
+        var patch = MakePatch(content);
+
+        string cachedPath = fs.Path.Combine(DownloadDir, "patch.patch");
+        fs.File.WriteAllBytes(cachedPath, content);
+        SetupDownload(provider, content);
+
+        var path = await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None);
+
+        Assert.That(path, Is.EqualTo(cachedPath));
+        provider.Verify(p => p.DownloadPatchAsync(It.IsAny<FeedInfo>(), It.IsAny<ReleasePatch>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedUpdateManifestTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedUpdateManifestTest.cs
@@ -1,0 +1,83 @@
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class ManifestReleasesFeedUpdateManifestTest
+{
+    private static (ManifestReleasesFeed Feed, Mock<IManifestReleasesFeedProviderService> Provider)
+        MakeFeed()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        var provider = new Mock<IManifestReleasesFeedProviderService>();
+        var log = new Mock<ILogService>();
+        var feedInfo = new FeedInfo { Repository = "KSP2Redux/Redux", Filename = "manifest-beta.json" };
+
+        var feed = new ManifestReleasesFeed(fs, provider.Object, log.Object, @"C:\downloads", feedInfo);
+        return (feed, provider);
+    }
+
+    private static ReleaseManifest MakeManifest(string channel, string version) => new()
+    {
+        Channel = channel,
+        GeneratedAt = new DateTime(2026, 1, 1),
+        SchemaVersion = 1,
+        Patches = [new ReleasePatch { Version = version, Requires = new PatchRequirement { Version = null }, Size = 1, Url = "https://x", ChecksumSha256 = "0", ReleasedAt = DateTime.UtcNow }],
+    };
+
+    [Test]
+    public async Task UpdateManifest_SucceedsThenReturnsNull_KeepsThePreviousPatchesAndChannel()
+    {
+        var (feed, provider) = MakeFeed();
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync(MakeManifest("beta", "1.2.3.4.5"));
+        Assert.That(await feed.UpdateManifest(), Is.True);
+
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync((ReleaseManifest?)null);
+        var succeeded = await feed.UpdateManifest();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(succeeded, Is.False, "A failed refresh should still report failure.");
+            Assert.That(feed.CurrentChannel, Is.EqualTo("beta"), "The last known channel must not be wiped out by a failed refresh.");
+            Assert.That(feed.GetAllVersions().Select(v => v.BuildNumber), Is.EqualTo(new[] { "5" }),
+                "A failed refresh must keep showing the last known patch list, not an empty one.");
+        });
+    }
+
+    [Test]
+    public async Task UpdateManifest_SucceedsThenThrows_KeepsThePreviousPatchesAndChannel()
+    {
+        var (feed, provider) = MakeFeed();
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync(MakeManifest("beta", "1.2.3.4.5"));
+        Assert.That(await feed.UpdateManifest(), Is.True);
+
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ThrowsAsync(new HttpRequestException("network unreachable"));
+        var succeeded = await feed.UpdateManifest();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(succeeded, Is.False);
+            Assert.That(feed.CurrentChannel, Is.EqualTo("beta"));
+            Assert.That(feed.GetAllVersions().Select(v => v.BuildNumber), Is.EqualTo(new[] { "5" }));
+        });
+    }
+
+    [Test]
+    public async Task UpdateManifest_NeverSucceededAndFails_FallsBackToAnEmptyInvalidManifest()
+    {
+        var (feed, provider) = MakeFeed();
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync((ReleaseManifest?)null);
+
+        var succeeded = await feed.UpdateManifest();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(succeeded, Is.False);
+            Assert.That(feed.CurrentChannel, Is.EqualTo("invalid"));
+            Assert.That(feed.GetAllVersions(), Is.Empty);
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Colors.axaml
+++ b/Ksp2Redux.Tools.Launcher/Colors.axaml
@@ -26,6 +26,11 @@
     <SolidColorBrush x:Key="DangerBrush" Color="{StaticResource DangerColor}" />
     <SolidColorBrush x:Key="DangerHoverBrush" Color="{StaticResource DangerHoverColor}" />
 
+    <!-- Semantic: non-urgent warnings (e.g. a background feed refresh that fell back to
+         cached data) - deliberately calmer than Danger since nothing is actually broken -->
+    <Color x:Key="WarningColor">#D9A441</Color>
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+
     <!-- Neutral buttons -->
     <Color x:Key="NeutralButtonColor">#666666</Color>
     <Color x:Key="NeutralButtonHoverColor">#333333</Color>

--- a/Ksp2Redux.Tools.Launcher/DefaultServiceProviderProvider.cs
+++ b/Ksp2Redux.Tools.Launcher/DefaultServiceProviderProvider.cs
@@ -42,6 +42,7 @@ public static class DefaultServiceProviderProvider
         serviceCollection.AddSingleton<IKsp2DetectorService, Ksp2DetectorService>();
         serviceCollection.AddSingleton<IMessageBoxService, MessageBoxService>();
         serviceCollection.AddSingleton<IOperatingSystemService, OperatingSystemService>();
+        serviceCollection.AddSingleton<IDiskSpaceService, DiskSpaceService>();
         return serviceCollection.BuildServiceProvider();
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
@@ -35,7 +35,8 @@ public class ManifestReleasesFeed
         _feed = feed;
     }
 
-    public async Task UpdateManifest()
+    /// <returns>false if the fetch failed and the channel was marked invalid, true otherwise.</returns>
+    public async Task<bool> UpdateManifest()
     {
         _log.Info($"Updating manifest for feed {_feed.Repository} / {_feed.Filename}.");
         try
@@ -52,10 +53,11 @@ public class ManifestReleasesFeed
                     GeneratedAt = DateTime.MinValue,
                 };
                 CurrentChannel = "invalid";
-                return;
+                return false;
             }
             CurrentChannel = _manifest.Channel;
             _log.Info($"Manifest loaded for {_feed.Repository} / {_feed.Filename}. Channel={CurrentChannel}, Patches={_manifest.Patches?.Count ?? 0}, GeneratedAt={_manifest.GeneratedAt:O}.");
+            return true;
         }
         catch (Exception e)
         {
@@ -68,6 +70,7 @@ public class ManifestReleasesFeed
                 GeneratedAt = DateTime.MinValue,
             };
             CurrentChannel = "invalid";
+            return false;
         }
     }
 

--- a/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
@@ -35,43 +35,46 @@ public class ManifestReleasesFeed
         _feed = feed;
     }
 
-    /// <returns>false if the fetch failed and the channel was marked invalid, true otherwise.</returns>
+    /// <returns>false if the fetch failed, true otherwise. On failure, a previously-loaded manifest
+    /// (and CurrentChannel) is left untouched rather than replaced, so callers showing a "using the
+    /// last known list" message after a failed refresh are telling the truth. Only falls back to an
+    /// empty "invalid" placeholder if there was never a successful fetch to fall back to.</returns>
     public async Task<bool> UpdateManifest()
     {
         _log.Info($"Updating manifest for feed {_feed.Repository} / {_feed.Filename}.");
         try
         {
-            _manifest = await _manifestReleasesFeedProviderService.GetManifest(_feed);
-            if (_manifest is null)
+            var manifest = await _manifestReleasesFeedProviderService.GetManifest(_feed);
+            if (manifest is null)
             {
-                _log.Warn($"Manifest for {_feed.Repository} / {_feed.Filename} was null. Marking channel as invalid.");
-                _manifest = new ReleaseManifest
-                {
-                    SchemaVersion = 0,
-                    Patches = [],
-                    Channel = "invalid",
-                    GeneratedAt = DateTime.MinValue,
-                };
-                CurrentChannel = "invalid";
+                _log.Warn($"Manifest for {_feed.Repository} / {_feed.Filename} was null. Keeping the last known list, if any.");
+                FallBackToInvalidIfNeverLoaded();
                 return false;
             }
+            _manifest = manifest;
             CurrentChannel = _manifest.Channel;
             _log.Info($"Manifest loaded for {_feed.Repository} / {_feed.Filename}. Channel={CurrentChannel}, Patches={_manifest.Patches?.Count ?? 0}, GeneratedAt={_manifest.GeneratedAt:O}.");
             return true;
         }
         catch (Exception e)
         {
-            _log.Error($"Could not download or parse manifest for {_feed.Repository} / {_feed.Filename}. Marking channel as invalid.", e);
-            _manifest = new ReleaseManifest
-            {
-                SchemaVersion = 0,
-                Patches = [],
-                Channel = "invalid",
-                GeneratedAt = DateTime.MinValue,
-            };
-            CurrentChannel = "invalid";
+            _log.Error($"Could not download or parse manifest for {_feed.Repository} / {_feed.Filename}. Keeping the last known list, if any.", e);
+            FallBackToInvalidIfNeverLoaded();
             return false;
         }
+    }
+
+    private void FallBackToInvalidIfNeverLoaded()
+    {
+        if (_manifest is not null) return;
+        _manifest = new ReleaseManifest
+        {
+            SchemaVersion = 0,
+            Patches = [],
+            Channel = "invalid",
+            GeneratedAt = DateTime.MinValue,
+        };
+        CurrentChannel = "invalid";
     }
 
     public IEnumerable<GameVersion> GetAllVersions()

--- a/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Ksp2Redux.Tools.Common;
@@ -170,30 +171,43 @@ public class ManifestReleasesFeed
         log($"Downloading {fileName}");
         reportDownloadProgress(0, patch.Size);
 
-        if (!_fileSystem.File.Exists(patchDownloadTo) || _fileSystem.FileInfo.New(patchDownloadTo).Length != patch.Size)
+        bool cacheIsUsable = _fileSystem.File.Exists(patchDownloadTo) &&
+                              _fileSystem.FileInfo.New(patchDownloadTo).Length == patch.Size &&
+                              await MatchesChecksum(patchDownloadTo, patch, ct);
+
+        if (!cacheIsUsable)
         {
             using var downloadResponse = await _manifestReleasesFeedProviderService.DownloadPatchAsync(_feed, patch, ct);
             long contentLength = downloadResponse.Content.Headers.ContentLength ?? patch.Size;
 
-            using var downloadStream = await downloadResponse.Content.ReadAsStreamAsync(ct);
-            using var fileStream = _fileSystem.FileStream.New(patchDownloadTo, FileMode.Create, FileAccess.Write, FileShare.None,
-                bufferSize: 64 * 1024, useAsync: true);
-
-            var buffer = new byte[64 * 1024];
-            long totalBytesRead = 0;
-            int bytesRead;
-            var updateTimer = Stopwatch.StartNew();
-
-            while ((bytesRead = await downloadStream.ReadAsync(buffer, ct)) > 0)
+            await using (var downloadStream = await downloadResponse.Content.ReadAsStreamAsync(ct))
+            await using (var fileStream = _fileSystem.FileStream.New(patchDownloadTo, FileMode.Create, FileAccess.Write, FileShare.None,
+                             bufferSize: 64 * 1024, useAsync: true))
             {
-                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
-                totalBytesRead += bytesRead;
+                var buffer = new byte[64 * 1024];
+                long totalBytesRead = 0;
+                int bytesRead;
+                var updateTimer = Stopwatch.StartNew();
 
-                if (updateTimer.ElapsedMilliseconds > 100)
+                while ((bytesRead = await downloadStream.ReadAsync(buffer, ct)) > 0)
                 {
-                    reportDownloadProgress(totalBytesRead, contentLength);
-                    updateTimer.Restart();
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
+                    totalBytesRead += bytesRead;
+
+                    if (updateTimer.ElapsedMilliseconds > 100)
+                    {
+                        reportDownloadProgress(totalBytesRead, contentLength);
+                        updateTimer.Restart();
+                    }
                 }
+            }
+
+            if (!await MatchesChecksum(patchDownloadTo, patch, ct))
+            {
+                _log.Error($"Downloaded {fileName} failed checksum verification. Deleting corrupt download.");
+                _fileSystem.File.Delete(patchDownloadTo);
+                throw new InvalidOperationException(
+                    $"Downloaded patch {fileName} did not match its expected checksum. The download may be corrupt or incomplete - please try again.");
             }
         }
         else
@@ -203,5 +217,19 @@ public class ManifestReleasesFeed
 
         log("Download complete.");
         return patchDownloadTo;
+    }
+
+    private async Task<bool> MatchesChecksum(string filePath, ReleasePatch patch, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(patch.ChecksumSha256))
+        {
+            _log.Error($"No checksum available for patch at {patch.Url}, refusing to trust it.");
+            return false;
+        }
+
+        await using var stream = _fileSystem.File.OpenRead(filePath);
+        var hash = await SHA256.HashDataAsync(stream, ct);
+        var actual = Convert.ToHexString(hash);
+        return string.Equals(actual, patch.ChecksumSha256, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/DiskSpaceService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/DiskSpaceService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+public interface IDiskSpaceService
+{
+    /// <summary>
+    /// Returns the free space available on the drive containing <paramref name="path"/>, in bytes.
+    /// Returns null if the drive could not be determined or queried.
+    /// </summary>
+    long? GetAvailableFreeSpace(string path);
+}
+
+public class DiskSpaceService(IFileSystem fileSystem) : IDiskSpaceService
+{
+    public long? GetAvailableFreeSpace(string path)
+    {
+        var root = fileSystem.Path.GetPathRoot(fileSystem.Path.GetFullPath(path));
+        if (string.IsNullOrEmpty(root)) return null;
+
+        try
+        {
+            return fileSystem.DriveInfo.New(root).AvailableFreeSpace;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/InstallFailedException.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/InstallFailedException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+/// <summary>
+/// Thrown by <see cref="InstallPlanService.ApplyToFolder"/> when a patch-apply step fails partway
+/// through. <see cref="RolledBack"/> indicates whether the install directory was successfully restored
+/// to its last known-good state (from uninstall.zip) before this was thrown.
+/// </summary>
+public sealed class InstallFailedException(string message, Exception innerException, bool rolledBack)
+    : Exception(message, innerException)
+{
+    public bool RolledBack { get; } = rolledBack;
+}

--- a/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ksp2Redux.Tools.Common;
@@ -18,11 +19,16 @@ public interface IInstallPlanService
 }
 
 public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheService, IEnvironmentProvider environmentProvider,
-    IAssemblyService assemblyService, IModuleDefinitionService moduleDefinitionService, IZipFileService zipFileService) : IInstallPlanService
+    IAssemblyService assemblyService, IModuleDefinitionService moduleDefinitionService, IZipFileService zipFileService,
+    IDiskSpaceService diskSpaceService) : IInstallPlanService
 {
     private const string EPIC_PREPATCH_NAME = "Ksp2Redux.Tools.Launcher.Prepatches.epic-prepatch.patch";
     private const string STEAM_PREPATCH_NAME = "Ksp2Redux.Tools.Launcher.Prepatches.steam-prepatch.patch";
     private const string PORTABLE_PREPATCH_NAME = "Ksp2Redux.Tools.Launcher.Prepatches.portable-prepatch.patch";
+
+    // Extra headroom on top of the raw estimate below, since patch application briefly holds both the
+    // old and new copy of a changed file, and the download itself needs to sit on disk before it's applied.
+    private const double RequiredSpaceSafetyMargin = 1.2;
     
     public void Describe(InstallPlan installPlan, Action<string> log)
     {
@@ -55,6 +61,8 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
     public async Task ApplyToFolder(InstallPlan installPlan, string install, Action<string> log,
         Action<long, long> downloadProgress, Action<int, int> stepsProgress, CancellationToken ct)
     {
+        EnsureEnoughDiskSpace(installPlan, install, log);
+
         var i = 0;
         foreach (var step in installPlan.Steps)
         {
@@ -137,7 +145,7 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
                     {
                         await patch.AsyncApply(environmentProvider, install, install, log, log);
                     }
-                    
+
                     delete_patch:
                     fileSystem.File.Delete(patchFile);
                     break;
@@ -164,5 +172,53 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
             stepsProgress(++i, installPlan.Steps.Count);
             await Task.Delay(250, ct);
         }
+    }
+
+    private void EnsureEnoughDiskSpace(InstallPlan installPlan, string install, Action<string> log)
+    {
+        long requiredBytes = installPlan.Cost;
+
+        // The first prepatch on an install snapshots the whole directory into uninstall.zip alongside it,
+        // so that needs to fit on the same drive too.
+        bool needsCacheSnapshot = installPlan.Steps.Any(s => s.Action == InstallPlanAction.Prepatch) &&
+                                   !fileSystem.File.Exists(fileSystem.Path.Combine(install, "uninstall.zip"));
+        if (needsCacheSnapshot)
+        {
+            requiredBytes += GetDirectorySize(install);
+        }
+
+        requiredBytes = (long)(requiredBytes * RequiredSpaceSafetyMargin);
+        if (requiredBytes <= 0) return;
+
+        var availableBytes = diskSpaceService.GetAvailableFreeSpace(install);
+        if (availableBytes is null)
+        {
+            log("Could not determine available disk space, skipping pre-flight space check.");
+            return;
+        }
+
+        if (availableBytes < requiredBytes)
+        {
+            throw new InvalidOperationException(
+                $"Not enough free disk space to continue: need approximately {FormatBytes(requiredBytes)}, " +
+                $"but only {FormatBytes(availableBytes.Value)} is available. Free up some space and try again.");
+        }
+    }
+
+    private long GetDirectorySize(string directory)
+    {
+        long total = 0;
+        foreach (var file in fileSystem.Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+        {
+            try { total += fileSystem.FileInfo.New(file).Length; }
+            catch (IOException) { /* file may have been removed/locked concurrently; ignore for this estimate */ }
+        }
+        return total;
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        double mb = bytes / (1024.0 * 1024.0);
+        return mb >= 1024 ? $"{mb / 1024.0:F1} GB" : $"{mb:F0} MB";
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Ksp2Redux.Tools.Common;
@@ -141,9 +142,14 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
                             throw new ArgumentOutOfRangeException();
                     }
 
-                    using (var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchFile))   // Test: Convert to factory, add interface for patch
+                    try
                     {
+                        using var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchFile);   // Test: Convert to factory, add interface for patch
                         await patch.AsyncApply(environmentProvider, install, install, log, log);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        RollbackOrRethrow(install, log, ex);
                     }
 
                     delete_patch:
@@ -154,9 +160,14 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
                 case InstallPlanAction.ApplyPatchFile:
                 {
                     var patchPath = await step.Argument!(log, downloadProgress, ct);
-                    using (var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchPath))
+                    try
                     {
+                        using var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchPath);
                         await patch.AsyncApply(environmentProvider, install, install, log, log);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        RollbackOrRethrow(install, log, ex);
                     }
                     if (step.DeleteAfter && fileSystem.File.Exists(patchPath))
                     {
@@ -172,6 +183,50 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
             stepsProgress(++i, installPlan.Steps.Count);
             await Task.Delay(250, ct);
         }
+    }
+
+    /// <summary>
+    /// Called when a Prepatch/ApplyPatchFile step throws partway through. If a known-good snapshot
+    /// (uninstall.zip) exists, restores it so a corrupt patch or a mid-write failure (e.g. disk full)
+    /// doesn't leave the install half-patched, then throws <see cref="InstallFailedException"/> describing
+    /// what happened. Note this restores the whole install to the last snapshot, which may discard other
+    /// patches already applied earlier in the same plan - still strictly better than a half-patched install.
+    /// If there is no snapshot to restore (nothing has been written to the install dir yet), rethrows the
+    /// original exception unchanged.
+    /// </summary>
+    private void RollbackOrRethrow(string install, Action<string> log, Exception original)
+    {
+        if (!fileSystem.File.Exists(fileSystem.Path.Combine(install, "uninstall.zip")))
+        {
+            ExceptionDispatchInfo.Capture(original).Throw();
+            return; // unreachable, keeps the compiler happy
+        }
+
+        log($"Install step failed ({original.Message}). Rolling back to the last known-good state...");
+
+        Exception? rollbackFailure = null;
+        try
+        {
+            cacheService.RecursivelyRestoreCache(install, true);
+        }
+        catch (Exception rollbackEx)
+        {
+            rollbackFailure = rollbackEx;
+        }
+
+        if (rollbackFailure is null)
+        {
+            log("Rolled back successfully.");
+            throw new InstallFailedException(
+                $"Installation failed and was automatically rolled back to the previous state. Original error: {original.Message}",
+                original, rolledBack: true);
+        }
+
+        log($"Rollback also failed: {rollbackFailure.Message}");
+        throw new InstallFailedException(
+            $"Installation failed ({original.Message}) and the automatic rollback also failed ({rollbackFailure.Message}). " +
+            "The install may be in a broken state - try Uninstall or Revert to Stock from Settings.",
+            original, rolledBack: false);
     }
 
     private void EnsureEnoughDiskSpace(InstallPlan installPlan, string install, Action<string> log)

--- a/Ksp2Redux.Tools.Launcher/Services/Ksp2InstallService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/Ksp2InstallService.cs
@@ -36,9 +36,9 @@ public interface IKsp2InstallService
     void ApplyActiveInstallBootConfig();
 }
 
-public class Ksp2InstallService(ILauncherConfigService launcherConfigService, IFileSystem fileSystem, IModuleDefinitionService moduleDefinitionService) : IKsp2InstallService
+public class Ksp2InstallService(ILauncherConfigService launcherConfigService, IFileSystem fileSystem, IModuleDefinitionService moduleDefinitionService, ILogService logService) : IKsp2InstallService
 {
-    private readonly HashSet<Guid> _checkedThisSession = new();
+    private readonly HashSet<Guid> _checkedThisSession = [];
 
     public Ksp2Install? Ksp2 { get; private set; }
 
@@ -249,7 +249,13 @@ public class Ksp2InstallService(ILauncherConfigService launcherConfigService, IF
             }
             fileSystem.File.WriteAllLines(bootConfigPath, lines);
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException ex)
+        {
+            logService.Warn($"Failed to write {bootConfigPath}: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logService.Warn($"Failed to write {bootConfigPath}: {ex.Message}");
+        }
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -42,6 +42,7 @@ public class UpdateService : IUpdateService
     private ILogService _log;
 
     private static bool _isSingleFile;
+    private bool _checkInProgress;
 
     private class GitHubReleaseAsset
     {
@@ -84,6 +85,27 @@ public class UpdateService : IUpdateService
     /// </summary>
     /// <returns>A boolean whether to allow updating redux versions after this</returns>
     public async Task<bool> CheckAndPerformUpdateAsync()
+    {
+        // Called on a 10-minute timer as well as at startup and from a manual button. If a check
+        // (and its "Update Found" dialog) is still awaiting a response, skip instead of stacking
+        // another dialog on top - left running overnight this used to pile up dozens of them.
+        if (_checkInProgress)
+        {
+            _log.Info("An update check is already in progress, skipping this one.");
+            return true;
+        }
+        _checkInProgress = true;
+        try
+        {
+            return await CheckAndPerformUpdateCoreAsync();
+        }
+        finally
+        {
+            _checkInProgress = false;
+        }
+    }
+
+    private async Task<bool> CheckAndPerformUpdateCoreAsync()
     {
         var releasesUrl = $"https://api.github.com/repos/{_owner}/{_repo}/releases";
         _log.Info($"Checking for launcher updates from {releasesUrl} (current version {_version}).");

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -55,8 +55,12 @@ public partial class HomeTabViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool MainButtonEnabled { get; set; }
 
+    // Null/empty means "no tooltip" - the enabled states below intentionally clear this, since
+    // a tooltip that just repeats the button's own label (e.g. "Install Ksp2Redux" on an already
+    // labeled INSTALL button) is redundant clutter. It's only worth showing when it explains why
+    // the button is disabled, which the label alone can't do.
     [ObservableProperty]
-    public partial string MainButtonTooltip { get; set; } = "Loading...";
+    public partial string? MainButtonTooltip { get; set; } = "Loading...";
 
     [ObservableProperty]
     public partial bool IsProgressVisible { get; set; }
@@ -297,13 +301,15 @@ public partial class HomeTabViewModel : ViewModelBase
         var linuxLaunchBlocked = _operatingSystemService.IsLinux() && !(_ksp2InstallService.ActiveEntry?.LaunchThroughSteam ?? false);
         const string linuxLaunchBlockedTooltip = "Enable \"Launch through Steam\" in settings to launch on Linux.";
 
+        const string installationDisabledTooltip = "The launcher needs to update itself before you can install or update Redux.";
+
         if (ksp2.Distribution != Distribution.Redux)
         {
             MainButtonEnabled = true;
+            MainButtonTooltip = null;
             if (selectedVersion.Version.Equals(ksp2.GameVersion) || selectedVersion.Channel == "installed")
             {
                 MainButtonShown = MainButtonState.Launch;
-                MainButtonTooltip = "Launch Stock KSP2";
                 if (linuxLaunchBlocked)
                 {
                     MainButtonEnabled = false;
@@ -314,7 +320,7 @@ public partial class HomeTabViewModel : ViewModelBase
             {
                 MainButtonEnabled = !InstallationDisabled;
                 MainButtonShown = MainButtonState.Install;
-                MainButtonTooltip = "Install Ksp2Redux";
+                if (InstallationDisabled) MainButtonTooltip = installationDisabledTooltip;
             }
             return;
         }
@@ -323,7 +329,7 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             MainButtonEnabled = true;
             MainButtonShown = MainButtonState.Launch;
-            MainButtonTooltip = "Launch Ksp2Redux";
+            MainButtonTooltip = null;
             if (linuxLaunchBlocked)
             {
                 MainButtonEnabled = false;
@@ -334,7 +340,7 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             MainButtonEnabled = !InstallationDisabled;
             MainButtonShown = MainButtonState.Update;
-            MainButtonTooltip = "Update Ksp2Redux";
+            MainButtonTooltip = InstallationDisabled ? installationDisabledTooltip : null;
         }
     }
 
@@ -410,7 +416,7 @@ public partial class HomeTabViewModel : ViewModelBase
         // Set up process cancellation trigger.
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
-        MainButtonTooltip = "Cancel installation";
+        MainButtonTooltip = null;
         _cancelCurrentOperation = new CancellationTokenSource();
 
         Log("Creating install plan");
@@ -471,7 +477,7 @@ public partial class HomeTabViewModel : ViewModelBase
         
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
-        MainButtonTooltip = "Cancel installation";
+        MainButtonTooltip = null;
         _cancelCurrentOperation = new CancellationTokenSource();
         
         try

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -6,11 +6,13 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
+using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Home;
 
@@ -22,6 +24,7 @@ public partial class HomeTabViewModel : ViewModelBase
     private readonly IInstallPlanService _installPlanService;
     private readonly IUpdateService _updateService;
     private readonly IOperatingSystemService _operatingSystemService;
+    private readonly IMessageBoxService _messageBoxService;
     private readonly ILogService _log;
     
     public ObservableCollection<GameVersionViewModel> Versions { get; } = [];
@@ -88,7 +91,7 @@ public partial class HomeTabViewModel : ViewModelBase
         item => (item as GameVersionViewModel)?.Channel ?? string.Empty;
 
     public HomeTabViewModel(IKsp2InstallService ksp2InstallService,
-        ILauncherConfigService launcherConfigService, IReleasesFeedService releasesFeedService, IInstallPlanService installPlanService, IUpdateService updateService, IOperatingSystemService operatingSystemService, ILogService log)
+        ILauncherConfigService launcherConfigService, IReleasesFeedService releasesFeedService, IInstallPlanService installPlanService, IUpdateService updateService, IOperatingSystemService operatingSystemService, IMessageBoxService messageBoxService, ILogService log)
     {
         _ksp2InstallService = ksp2InstallService;
         _launcherConfigService = launcherConfigService;
@@ -96,6 +99,7 @@ public partial class HomeTabViewModel : ViewModelBase
         _installPlanService = installPlanService;
         _updateService = updateService;
         _operatingSystemService = operatingSystemService;
+        _messageBoxService = messageBoxService;
         _log = log;
 
         RebuildInstallsCollection();
@@ -589,6 +593,9 @@ public partial class HomeTabViewModel : ViewModelBase
         catch (Exception ex)
         {
             _log.Error("Manual launcher update failed.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Update Failed!",
+                $"Something went wrong while checking for launcher updates: {ex.Message}\nPlease try again later.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
         }
     }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -380,6 +380,10 @@ public partial class HomeTabViewModel : ViewModelBase
             await RunPlanOnInstall(plan, ksp2);
             Log("KSP2 Redux Successfully Installed");
         }
+        catch (OperationCanceledException)
+        {
+            Log("Installation cancelled");
+        }
         catch (Exception e)
         {
             Log($"Error updating Redux: {e.Message}");
@@ -428,6 +432,10 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             await RunPlanOnInstall(plan, ksp2);
             Log("KSP2 Redux Successfully Installed");
+        }
+        catch (OperationCanceledException)
+        {
+            Log("Installation cancelled");
         }
         catch (Exception e)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -27,9 +27,17 @@ public partial class HomeTabViewModel : ViewModelBase
     public ObservableCollection<GameVersionViewModel> Versions { get; } = [];
     public ObservableCollection<Ksp2InstallChoiceViewModel> Installs { get; } = [];
 
-    [ObservableProperty] private GameVersionViewModel? _selectedVersion;
-    [ObservableProperty] private Ksp2InstallChoiceViewModel? _selectedInstall;
-    [ObservableProperty] private bool _isInstallSwitcherEnabled;
+    [ObservableProperty]
+    public partial GameVersionViewModel? SelectedVersion { get; set; }
+
+    [ObservableProperty]
+    public partial Ksp2InstallChoiceViewModel? SelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsInstallSwitcherEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial bool FeedRefreshFailed { get; set; }
 
     public enum MainButtonState
     {
@@ -38,18 +46,39 @@ public partial class HomeTabViewModel : ViewModelBase
         Update,
         Cancel,
     }
-    [ObservableProperty] private MainButtonState _mainButtonShown;
-    [ObservableProperty] private bool _mainButtonEnabled;
-    [ObservableProperty] private string _mainButtonTooltip = "Loading...";
-    [ObservableProperty] private bool _isProgressVisible;
-    [ObservableProperty] private float _downloadProgressMb = 250;
-    [ObservableProperty] private float _downloadProgressTotalMb = 450;
-    [ObservableProperty] private float _installProgressSteps = 1;
-    [ObservableProperty] private float _installProgressTotalSteps = 3;
-    [ObservableProperty] private bool _isInstallLogVisible;
-    [ObservableProperty] private string _installLogText = string.Empty;
-    [ObservableProperty] private bool _installationDisabled;
-    
+    [ObservableProperty]
+    public partial MainButtonState MainButtonShown { get; set; }
+
+    [ObservableProperty]
+    public partial bool MainButtonEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial string MainButtonTooltip { get; set; } = "Loading...";
+
+    [ObservableProperty]
+    public partial bool IsProgressVisible { get; set; }
+
+    [ObservableProperty]
+    public partial float DownloadProgressMb { get; set; } = 250;
+
+    [ObservableProperty]
+    public partial float DownloadProgressTotalMb { get; set; } = 450;
+
+    [ObservableProperty]
+    public partial float InstallProgressSteps { get; set; } = 1;
+
+    [ObservableProperty]
+    public partial float InstallProgressTotalSteps { get; set; } = 3;
+
+    [ObservableProperty]
+    public partial bool IsInstallLogVisible { get; set; }
+
+    [ObservableProperty]
+    public partial string InstallLogText { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial bool InstallationDisabled { get; set; }
+
     private readonly StringBuilder _installLogBuilder = new();
     private readonly Lock _installLogLock = new();
     private bool _installLogUpdateQueued;
@@ -130,10 +159,12 @@ public partial class HomeTabViewModel : ViewModelBase
     }
     private async Task UpdateAsync()
     {
+        var allSucceeded = true;
         foreach (var feed in _releasesFeedService.ReleasesFeed)
         {
-            await feed.Value.UpdateManifest();
+            if (!await feed.Value.UpdateManifest()) allSucceeded = false;
         }
+        FeedRefreshFailed = !allSucceeded;
     }
 
     // Single refresh entry point shared by the periodic timer and, later, a manual button / F5.

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -125,7 +125,7 @@ public partial class HomeTabViewModel : ViewModelBase
     {
         if(updateChannels)
             await UpdateAsync();
-        RebuildVersionsCollection();
+        RebuildVersionsCollectionPreservingSelection();
         UpdateMainButtonState();
     }
     private async Task UpdateAsync()
@@ -146,10 +146,18 @@ public partial class HomeTabViewModel : ViewModelBase
         // otherwise a background refresh would clobber the Cancel button mid operation.
         if (_cancelCurrentOperation is not null) return;
 
-        // RebuildVersionsCollection resets SelectedVersion to a default, which would pull the
-        // user's choice out from under them on every periodic refresh. Capture and restore it.
-        var previous = SelectedVersion;
         await UpdateAsync();
+        RebuildVersionsCollectionPreservingSelection();
+        UpdateMainButtonState();
+    }
+
+    // RebuildVersionsCollection resets SelectedVersion to a default, which would pull the user's
+    // choice out from under them any time the list gets rebuilt - a periodic feed refresh, or an
+    // unrelated settings change to the active install (which also fires ActiveInstallChanged).
+    // Capture and restore it around the rebuild instead.
+    private void RebuildVersionsCollectionPreservingSelection()
+    {
+        var previous = SelectedVersion;
         RebuildVersionsCollection();
         if (previous is not null)
         {
@@ -157,7 +165,6 @@ public partial class HomeTabViewModel : ViewModelBase
                 v.Channel == previous.Channel && v.Version.Equals(previous.Version));
             if (match is not null) SelectedVersion = match;
         }
-        UpdateMainButtonState();
     }
 
     [RelayCommand]

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -384,6 +384,10 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             Log("Installation cancelled");
         }
+        catch (InstallFailedException e)
+        {
+            Log(e.Message);
+        }
         catch (Exception e)
         {
             Log($"Error updating Redux: {e.Message}");
@@ -436,6 +440,10 @@ public partial class HomeTabViewModel : ViewModelBase
         catch (OperationCanceledException)
         {
             Log("Installation cancelled");
+        }
+        catch (InstallFailedException e)
+        {
+            Log(e.Message);
         }
         catch (Exception e)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -38,10 +38,11 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IMessageBoxService _messageBoxService;
     private readonly ILogService _log;
 
-    [ObservableProperty] private InstallState _currentInstallState;
+    [ObservableProperty]
+    public partial InstallState CurrentInstallState { get; set; }
 
-    [ObservableProperty] private bool _isUpdateDownloading;
-
+    [ObservableProperty]
+    public partial bool IsUpdateDownloading { get; set; }
     public HomeTabViewModel HomeTab { get; }
     public CommunityTabViewModel CommunityTab { get; }
     public ModsTabViewModel ModsTab { get; }
@@ -49,13 +50,15 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public Shared.NewsCollectionViewModel NewsCollectionViewModel { get; }
 
-    [ObservableProperty] private int _currentTab;
+    [ObservableProperty]
+    public partial int CurrentTab { get; set; }
 
     // Drives the blurred backdrop behind whichever glass panel (Home log, Community
     // article, Settings, Mods) is currently on screen. Home and Community don't always
     // have one showing, so this has to react to their own visibility state too, not just
     // which tab is selected.
-    [ObservableProperty] private bool _isContentPanelVisible;
+    [ObservableProperty]
+    public partial bool IsContentPanelVisible { get; set; }
 
     public MainWindowViewModel(HomeTabViewModel homeTab, CommunityTabViewModel communityTab, ModsTabViewModel modsTab,
         SettingsTabViewModel settingsTabViewModel, IKsp2InstallService ksp2InstallService,

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -120,7 +120,7 @@ public partial class MainWindowViewModel : ViewModelBase
         };
         UpdateContentPanelVisible();
 
-        _ = InitializeAsync().ContinueWith(LogErrors);
+        _ = InitializeAsync().ContinueWith(HandleInitializeFailure);
 
         var timer = new DispatcherTimer
         {
@@ -141,6 +141,21 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             _log.Error("Background task faulted.", antecedent.Exception);
         }
+    }
+
+    // Startup initialization failing is more severe than a background task like the news feed
+    // failing to load (which just leaves a list empty) - if this throws, feeds/install detection/
+    // the update check may not have run at all, so tell the user instead of failing silently.
+    private void HandleInitializeFailure(Task antecedent)
+    {
+        if (!antecedent.IsFaulted) return;
+        _log.Error("Startup initialization failed.", antecedent.Exception);
+        Dispatcher.UIThread.Post(async () =>
+        {
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Startup Error",
+                "Something went wrong while starting up, so setup may be incomplete (feeds, install detection, or the update check may not have run). Check the log file for details, and consider restarting the launcher.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+        });
     }
 
     private async Task InitializeAsync()

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
@@ -12,14 +12,29 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
 
     public Guid Id => _entry.Id;
 
-    [ObservableProperty] private string _name;
-    [ObservableProperty] private string _exePath;
-    [ObservableProperty] private string _releaseChannel;
-    [ObservableProperty] private bool _isActive;
-    [ObservableProperty] private bool _launchThroughSteam;
-    [ObservableProperty] private string _steamAppId;
-    [ObservableProperty] private string _launchArguments;
-    [ObservableProperty] private bool _disableGraphicsJobs;
+    [ObservableProperty]
+    public partial string Name { get; set; }
+
+    [ObservableProperty]
+    public partial string ExePath { get; set; }
+
+    [ObservableProperty]
+    public partial string ReleaseChannel { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsActive { get; set; }
+
+    [ObservableProperty]
+    public partial bool LaunchThroughSteam { get; set; }
+
+    [ObservableProperty]
+    public partial string SteamAppId { get; set; }
+
+    [ObservableProperty]
+    public partial string LaunchArguments { get; set; }
+
+    [ObservableProperty]
+    public partial bool DisableGraphicsJobs { get; set; }
 
     public Ksp2InstallRowViewModel(IKsp2InstallService ksp2InstallService, Ksp2InstallEntry entry, bool isActive)
     {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -31,9 +31,14 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     public ObservableCollection<string> ValidChannels { get; } = [];
 
-    [ObservableProperty] private Ksp2InstallRowViewModel? _selectedInstall;
-    [ObservableProperty] private bool _hasSelectedInstall;
-    [ObservableProperty] private bool _canRemoveSelectedInstall;
+    [ObservableProperty]
+    public partial Ksp2InstallRowViewModel? SelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool HasSelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool CanRemoveSelectedInstall { get; set; }
 
     public string LauncherVersion => _assemblyService.GetVersion()?.ToString(4) ?? "?";
 

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
@@ -174,6 +174,12 @@
                     VerticalAlignment="Stretch"
                     Margin="6,0,0,0" />
             </Grid>
+            <TextBlock Name="FeedRefreshWarning"
+                       IsVisible="{Binding FeedRefreshFailed}"
+                       Text="Couldn't refresh versions - showing the last known list."
+                       Foreground="{StaticResource WarningBrush}"
+                       FontSize="10" TextWrapping="Wrap"
+                       Margin="2,4,0,0" />
           </StackPanel>
         </StackPanel>
 

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
@@ -180,8 +180,7 @@
         <Panel Grid.Row="3" DataContext="{Binding HomeTab}">
           <Panel x:DataType="home:HomeTabViewModel">
             <Button Classes="main-button" IsVisible="True" Name="InstallButton" Command="{Binding InstallRedux}"
-                    IsEnabled="{Binding MainButtonEnabled}"
-                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
+                    IsEnabled="{Binding MainButtonEnabled}">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-install.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
@@ -186,7 +186,8 @@
         <Panel Grid.Row="3" DataContext="{Binding HomeTab}">
           <Panel x:DataType="home:HomeTabViewModel">
             <Button Classes="main-button" IsVisible="True" Name="InstallButton" Command="{Binding InstallRedux}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-install.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />
@@ -194,7 +195,8 @@
                 </Canvas>
             </Button>
             <Button Classes="main-button" IsVisible="False" Name="UpdateButton" Command="{Binding UpdateRedux}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-update.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />
@@ -202,7 +204,8 @@
                 </Canvas>
             </Button>
             <Button Classes="main-button" IsVisible="False" Name="CancelButton" ClickMode="Press" Command="{Binding CancelCurrentMainButtonAction}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-cancel.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />
@@ -210,7 +213,8 @@
                 </Canvas>
             </Button>
             <Button Classes="main-button" IsVisible="False" Name="LaunchButton" Command="{Binding LaunchGame}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-launch.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />


### PR DESCRIPTION
## Summary
Foundational reliability pass for v0.2.0: the first round of fixes for install/update failures that either corrupted state or left the user with no idea anything had gone wrong. This is the base the six later "reliability audit" batches (#37–#42) stack on top of.

- **Swallowed IO exceptions when writing boot.config** - `ApplyActiveInstallBootConfig` had empty catch blocks for `IOException`/`UnauthorizedAccessException`, so a failure to toggle the graphics-jobs flag (locked file, permissions) silently produced zero feedback anywhere, not even in the log.
- **No checksum verification on downloaded patches** - `DownloadPatch` only checked file length against the manifest, never a hash, even though `ReleasePatch.ChecksumSha256` was already populated by the uploader and just sitting unused. A truncated or corrupted download would previously proceed straight to patch application. Now verifies the hash (fail-closed if missing) both after a fresh download and before trusting a cached file, deleting anything that fails and forcing a redownload.
- **Cancelling an install was treated as an error** - Cancelling an install/update fell into the same generic catch used for real failures, showing "Error updating Redux: The operation was canceled." plus a scary "Redux may be in an invalid state" warning, indistinguishable from an actual failure. Cancel now gets its own branch with a plain "Installation cancelled" message.
- **No disk-space pre-check before install/update** - A large patch on a nearly-full drive would fail partway through instead of being caught upfront. Adds a small `IDiskSpaceService` (wrapping `IFileSystem.DriveInfo`, since `System.IO.DriveInfo` is banned by the project's analyzer rules) that checks the plan's total download size plus, when a fresh `uninstall.zip` snapshot will be created, the current install directory's size too, with a 20% safety margin.
- **No rollback on a partial install/patch failure** - The Prepatch and ApplyPatchFile steps had no error handling around the actual patch-apply calls, so a corrupted patch or a disk-full failure mid-install left the game in a half-patched state. Both steps now restore from `uninstall.zip` (via the existing cache snapshot/restore mechanism) when they fail partway through, and raise a new `InstallFailedException` describing whether the rollback itself succeeded, instead of leaving things broken with no way to know.
- **Feed refresh failures were invisible** - `ManifestReleasesFeed.UpdateManifest` degraded a channel to "invalid" on network/parse failure with only a log line, the user had no way to know their version list was stale/incomplete. It now returns whether it succeeded, `HomeTabViewModel` aggregates that across all feeds, and the sidebar shows a small non-blocking banner near the version dropdown when a refresh fails. Clears again on the next successful refresh.
- **Two more silent-failure spots** - `HomeTabViewModel.UpdateLauncher`'s catch only logged if a manual "check for updates" retry threw unexpectedly, leaving the user clicking a button that visibly did nothing; it now shows the same "Update Failed!" dialog used elsewhere. `MainWindowViewModel.InitializeAsync` could fail (feeds, install detection, update check may not run at all) with only a log line; this is now split out into its own handler that additionally shows a "Startup Error" dialog pointing at the log file.
