### PR TITLE
Updater v0.1.1

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionSelectionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionSelectionTest.cs
@@ -1,0 +1,95 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Controls;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class VersionSelectionTest
+{
+    private const string DefaultChannel = "beta";
+    private const string OtherChannel = "stable";
+
+    [AvaloniaTest]
+    public void ChangingAnInstallSetting_DoesNotResetTheSelectedVersion()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        ReleasePatch patch = new()
+        {
+            ChecksumSha256 = "0",
+            ReleasedAt = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Requires = new PatchRequirement { Version = null },
+            Size = 10,
+            Url = "https://github.com/patch1Rollup.patch",
+            Version = "0.2.3.1.1234",
+        };
+
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel))))
+            .ReturnsAsync(new ReleaseManifest
+            {
+                Channel = DefaultChannel,
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [patch],
+                SchemaVersion = 1
+            });
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel) == false)))
+            .ReturnsAsync((FeedInfo f) => new ReleaseManifest
+            {
+                Channel = f.Filename.Split('-', '.')[1],
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [],
+                SchemaVersion = 1
+            });
+
+        // Act
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        GroupedComboBox? versionSelectorCombobox = window
+            .GetVisualDescendants()
+            .OfType<GroupedComboBox>()
+            .FirstOrDefault(x => x.Name == "VersionSelector");
+        Assert.That(versionSelectorCombobox, Is.Not.Null);
+
+        var nonDefaultVersion = versionSelectorCombobox.GroupedItems
+            .OfType<GameVersionViewModel>()
+            .Single(g => g.VersionString.Contains("0.2.3.1.1234"));
+        versionSelectorCombobox.SelectedItem = nonDefaultVersion;
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+        Assert.That(homeTabViewModel.SelectedVersion?.VersionString, Does.Contain("0.2.3.1.1234"));
+
+        // Simulate a settings-page change to the active install (e.g. toggling "disable graphics jobs"),
+        // which fires ActiveInstallChanged - this used to silently reset the version dropdown.
+        var ksp2InstallService = TestAppBuilder.ServiceProvider.GetRequiredService<IKsp2InstallService>();
+        var activeEntryId = ksp2InstallService.ActiveEntry!.Id;
+        ksp2InstallService.UpdateInstallDisableGraphicsJobs(activeEntryId, true);
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert
+        Assert.That(homeTabViewModel.SelectedVersion?.VersionString, Does.Contain("0.2.3.1.1234"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -42,6 +42,7 @@ public class UpdateService : IUpdateService
     private ILogService _log;
 
     private static bool _isSingleFile;
+    private bool _checkInProgress;
 
     private class GitHubReleaseAsset
     {
@@ -84,6 +85,27 @@ public class UpdateService : IUpdateService
     /// </summary>
     /// <returns>A boolean whether to allow updating redux versions after this</returns>
     public async Task<bool> CheckAndPerformUpdateAsync()
+    {
+        // Called on a 10-minute timer as well as at startup and from a manual button. If a check
+        // (and its "Update Found" dialog) is still awaiting a response, skip instead of stacking
+        // another dialog on top - left running overnight this used to pile up dozens of them.
+        if (_checkInProgress)
+        {
+            _log.Info("An update check is already in progress, skipping this one.");
+            return true;
+        }
+        _checkInProgress = true;
+        try
+        {
+            return await CheckAndPerformUpdateCoreAsync();
+        }
+        finally
+        {
+            _checkInProgress = false;
+        }
+    }
+
+    private async Task<bool> CheckAndPerformUpdateCoreAsync()
     {
         var releasesUrl = $"https://api.github.com/repos/{_owner}/{_repo}/releases";
         _log.Info($"Checking for launcher updates from {releasesUrl} (current version {_version}).");

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -125,7 +125,7 @@ public partial class HomeTabViewModel : ViewModelBase
     {
         if(updateChannels)
             await UpdateAsync();
-        RebuildVersionsCollection();
+        RebuildVersionsCollectionPreservingSelection();
         UpdateMainButtonState();
     }
     private async Task UpdateAsync()
@@ -146,10 +146,18 @@ public partial class HomeTabViewModel : ViewModelBase
         // otherwise a background refresh would clobber the Cancel button mid operation.
         if (_cancelCurrentOperation is not null) return;
 
-        // RebuildVersionsCollection resets SelectedVersion to a default, which would pull the
-        // user's choice out from under them on every periodic refresh. Capture and restore it.
-        var previous = SelectedVersion;
         await UpdateAsync();
+        RebuildVersionsCollectionPreservingSelection();
+        UpdateMainButtonState();
+    }
+
+    // RebuildVersionsCollection resets SelectedVersion to a default, which would pull the user's
+    // choice out from under them any time the list gets rebuilt - a periodic feed refresh, or an
+    // unrelated settings change to the active install (which also fires ActiveInstallChanged).
+    // Capture and restore it around the rebuild instead.
+    private void RebuildVersionsCollectionPreservingSelection()
+    {
+        var previous = SelectedVersion;
         RebuildVersionsCollection();
         if (previous is not null)
         {
@@ -157,7 +165,6 @@ public partial class HomeTabViewModel : ViewModelBase
                 v.Channel == previous.Channel && v.Version.Equals(previous.Version));
             if (match is not null) SelectedVersion = match;
         }
-        UpdateMainButtonState();
     }
 
     [RelayCommand]

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
@@ -180,8 +180,7 @@
         <Panel Grid.Row="3" DataContext="{Binding HomeTab}">
           <Panel x:DataType="home:HomeTabViewModel">
             <Button Classes="main-button" IsVisible="True" Name="InstallButton" Command="{Binding InstallRedux}"
-                    IsEnabled="{Binding MainButtonEnabled}"
-                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
+                    IsEnabled="{Binding MainButtonEnabled}">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-install.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />


### PR DESCRIPTION
**Full Changelog**: https://github.com/KSP2Redux/Updater/compare/updater-v0.1.0...updater-v0.1.1

## What's Changed

### Fixed:
* Update-available dialogs could pile up into dozens of stacked windows if left unanswered for a while _(e.g. running overnight)_  It now checks now skip instead of stacking while one is already pending.
* Changing any setting on the Settings page _(toggling graphics jobs, renaming an install, changing the exe path, etc.)_ was resetting the version dropdown back to the currently installed version, discarding your selection.
* Removed a leftover tooltip on the Install button that stuck around after the same cleanup was done for Update/Cancel.