### PR TITLE
Stop the crashes: guard the highest-traffic failure points

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UninstallFailureTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UninstallFailureTest.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class UninstallFailureTest
+{
+    [AvaloniaTest]
+    public async Task UninstallRedux_RestoreCacheThrows_ShowsErrorInsteadOfCrashing()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        const string installDir = @"C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program 2";
+        TestAppBuilder.FileSystem.File.WriteAllBytes(TestAppBuilder.FileSystem.Path.Combine(installDir, "uninstall.zip"), [0x00]);
+        TestAppBuilder.ZipFileService
+            .Setup(z => z.OpenRead(TestAppBuilder.FileSystem.Path.Combine(installDir, "uninstall.zip")))
+            .Throws(new IOException("uninstall.zip is locked by another process"));
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var settingsTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<SettingsTabViewModel>();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await settingsTabViewModel.UninstallRedux();
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert
+        Assert.That(thrown, Is.Null, "Uninstall failure must not propagate as an unhandled exception.");
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Error!",
+                It.Is<string>(s => s.Contains("Couldn't uninstall Redux") && s.Contains("locked by another process")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/LauncherConfigServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LauncherConfigServiceTest.cs
@@ -2,6 +2,7 @@
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
 using Moq;
+using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.Test;
 
@@ -91,7 +92,7 @@ public class LauncherConfigServiceTest
         
         // Act Assert
         Assert.That(
-            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object),
+            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object),
             Throws.Exception);
         directory.Verify(d => d.CreateDirectory("incorrect combined path"), Times.Never,
             "Tried to create a directory for the config when appdata didn't exist");
@@ -132,7 +133,7 @@ public class LauncherConfigServiceTest
         
         // Act Assert
         Assert.That(
-            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object),
+            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object),
             Throws.Exception);
         directory.Verify(d => d.CreateDirectory("incorrect combined path"), Times.Never,
             "Tried to create a directory for the config when appdata didn't exist");
@@ -166,7 +167,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         
         // Assert
         file.Verify(f => f.WriteAllText("/appdata/Ksp2Redux/redux-launcher-config.json", It.IsAny<string>()), Times.Once);
@@ -199,7 +200,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         
         // Assert
         file.Verify(f => f.WriteAllText("/appdata/Ksp2Redux/redux-launcher-config.json", It.IsAny<string>()), Times.Once);
@@ -232,7 +233,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         
         // Assert
         file.Verify(f => f.WriteAllText("/appdata/Ksp2Redux/redux-launcher-config.json", It.IsAny<string>()), Times.Once);
@@ -265,7 +266,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
 
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
 
         // Assert: legacy single-install was migrated to the new schema.
         var cfg = launcherConfigService.Config;
@@ -308,7 +309,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
 
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
 
         // Assert
         var cfg = launcherConfigService.Config;
@@ -320,7 +321,7 @@ public class LauncherConfigServiceTest
     
     // Save
     [Test]
-    public void Save_NullStoragePathDirectoryName_ThrowsException()
+    public void Save_NullStoragePathDirectoryName_ReportsFailureInsteadOfThrowing()
     {
         // Arrange
         Mock<IEnvironmentProvider> environmentProvider  = new();
@@ -328,6 +329,7 @@ public class LauncherConfigServiceTest
         Mock<IDirectory> directory = new();
         Mock<IFile> file = new();
         Mock<IFileSystem> fileSystem = new();
+        Mock<ILogService> log = new();
 
         // Pass constructor quickly without issues
         environmentProvider.Setup(ep => ep.GetFolderPath(Environment.SpecialFolder.LocalApplicationData))
@@ -337,11 +339,15 @@ public class LauncherConfigServiceTest
         path.Setup(p => p.Combine("/appdata/Ksp2Redux", "redux-launcher-config.json"))
             .Returns("configFilePath");
         file.Setup(f => f.ReadAllText("configFilePath")).Returns(simpleLauncherConfigJson);
-        
+        // simpleLauncherConfigJson is legacy-schema, so construction triggers a migration Save() too -
+        // give that one a valid directory so only the explicit Save() below hits the failure path.
+        path.Setup(p => p.GetDirectoryName("configFilePath"))
+            .Returns("/appdata/Ksp2Redux");
+
         // Test method
         path.Setup(p => p.GetDirectoryName("storage path"))
             .Returns((string?)null);
-        
+
         fileSystem.SetupGet(fs => fs.Path).Returns(path.Object);
         fileSystem.SetupGet(fs => fs.Directory).Returns(directory.Object);
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
@@ -349,7 +355,7 @@ public class LauncherConfigServiceTest
         LauncherConfigService launcherConfigService = null!;
         try
         {
-            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, log.Object);
         }
         catch(Exception e)
         {
@@ -360,13 +366,15 @@ public class LauncherConfigServiceTest
         {
             StoragePath = "storage path"
         };
-        
-        // Act Assert
-        Assert.That(() => launcherConfigService.Save(), Throws.Exception);
-        directory.Verify(d => d.CreateDirectory(It.IsNotIn("/appdata/Ksp2Redux")), Times.Never, 
+
+        // Act Assert - a failed save must never throw back into a UI data-binding callback; it should
+        // be logged instead so the app stays up (see the "stop the crashes" hardening pass).
+        Assert.That(() => launcherConfigService.Save(), Throws.Nothing);
+        log.Verify(l => l.Error(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        directory.Verify(d => d.CreateDirectory(It.IsNotIn("/appdata/Ksp2Redux")), Times.Never,
             "Tried creating a directory when IPath.GetDirectoryName returned null");
-        file.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never,
-            "Tried creating a directory when IPath.GetDirectoryName returned null");
+        file.Verify(f => f.WriteAllText("storage path", It.IsAny<string>()), Times.Never,
+            "Tried writing to storage path when IPath.GetDirectoryName returned null");
     }
     
     [Test]
@@ -402,7 +410,7 @@ public class LauncherConfigServiceTest
         LauncherConfigService launcherConfigService = null!;
         try
         {
-            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         }
         catch(Exception e)
         {

--- a/Ksp2Redux.Tools.Launcher/App.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/App.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -23,7 +24,24 @@ public partial class App(IServiceProvider? serviceProvider = null) : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
-        _serviceProvider ??= DefaultServiceProviderProvider.GetDefaultServiceProvider();
+        // Building the DI container touches disk (config load), so it can fail before the logger or
+        // any exception handler exists. Without this, a broken first run just silently vanishes with
+        // nothing to go on - "launcher won't open" bug reports with zero log evidence.
+        try
+        {
+            _serviceProvider ??= DefaultServiceProviderProvider.GetDefaultServiceProvider();
+        }
+        catch (Exception ex)
+        {
+            LogService.WriteEarly($"Fatal startup failure while initializing services: {ex}");
+            ShowFatalStartupError(ex);
+            // IEnvironmentProvider isn't available - the container that would provide it is exactly
+            // what just failed to build.
+#pragma warning disable RS0030
+            Environment.Exit(1);
+#pragma warning restore RS0030
+            return;
+        }
 
         var log = _serviceProvider.GetRequiredService<ILogService>();
         log.Info($"Launcher starting. Log file: {log.CurrentLogFilePath ?? "(console only)"}");
@@ -46,6 +64,28 @@ public partial class App(IServiceProvider? serviceProvider = null) : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    // Deliberately bypasses Avalonia/MsBox.Avalonia entirely - the framework may not be usable yet at
+    // this point, since this only runs when building the DI container (and therefore most of the app's
+    // own services) already failed. A plain native message box has no dependency on any of that.
+    private static void ShowFatalStartupError(Exception ex)
+    {
+        var message = $"KSP2 Redux failed to start:\n\n{ex.Message}\n\n" +
+                      "A bootstrap.log with more detail was written to your logs folder.";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            try
+            {
+                NativeMessageBox.ShowError(message, "KSP2 Redux - Startup Failed");
+                return;
+            }
+            catch (Exception showEx)
+            {
+                LogService.WriteEarly($"Could not show native startup-error dialog: {showEx}");
+            }
+        }
+        Console.Error.WriteLine(message);
     }
 
     private static void HookGlobalExceptionHandlers(ILogService log)

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.1.1</Version>
+        <Version>0.2.0</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/Models/GameVersion.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/GameVersion.cs
@@ -16,7 +16,7 @@ public class GameVersion : IEquatable<GameVersion>
     /// <summary>
     /// Read version data VersionID class constants in Assembly-CSharp.dll
     /// </summary>
-    public static GameVersion FromVersionIDType(TypeDefinition versionType, bool IsRedux)
+    public static GameVersion FromVersionIDType(TypeDefinition versionType, bool isRedux)
     {
         string channel = "stable";
         Version version;
@@ -58,7 +58,7 @@ public class GameVersion : IEquatable<GameVersion>
         if (string.IsNullOrWhiteSpace(buildNumber))
             throw new InvalidOperationException($"VERSION_TEXT has an invalid build number: '{versionText}'.");
 
-        if (IsRedux)
+        if (isRedux)
             channel = GetRequiredFieldValueAsString("CHANNEL_NAME");
 
         // try get redux commit hash

--- a/Ksp2Redux.Tools.Launcher/NativeMessageBox.cs
+++ b/Ksp2Redux.Tools.Launcher/NativeMessageBox.cs
@@ -1,0 +1,22 @@
+using System.Runtime.InteropServices;
+
+namespace Ksp2Redux.Tools.Launcher;
+
+/// <summary>
+/// A plain Win32 message box with zero managed dependencies, for reporting failures so early
+/// (e.g. the DI container itself failing to build) that Avalonia's own dialog stack may not be
+/// safe to use yet.
+/// </summary>
+internal static class NativeMessageBox
+{
+    private const uint MB_OK = 0x0;
+    private const uint MB_ICONERROR = 0x10;
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int MessageBoxW(nint hWnd, string text, string caption, uint type);
+
+    public static void ShowError(string text, string caption)
+    {
+        MessageBoxW(0, text, caption, MB_OK | MB_ICONERROR);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.IO.Abstractions;
 using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Threading;
 using Ksp2Redux.Tools.Launcher.Models;
+using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
 
@@ -16,17 +19,21 @@ public class LauncherConfigService : ILauncherConfigService
 {
     private readonly IFileSystem _fileSystem;
     private readonly IEnvironmentProvider _environmentProvider;
+    private readonly IMessageBoxService _messageBoxService;
     private readonly ILogService _log;
+    private bool _showingSaveFailureDialog;
 
     public LauncherConfig Config { get; set; }
     private readonly JsonSerializerOptions StorageOptions = new() { WriteIndented = true };
 
     private const string LauncherConfigJson = "redux-launcher-config.json";
 
-    public LauncherConfigService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, ILogService log)
+    public LauncherConfigService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider,
+        IMessageBoxService messageBoxService, ILogService log)
     {
         _fileSystem = fileSystem;
         _environmentProvider = environmentProvider;
+        _messageBoxService = messageBoxService;
         _log = log;
         GetOrCreateCurrentConfig(_fileSystem);
     }
@@ -117,22 +124,54 @@ public class LauncherConfigService : ILauncherConfigService
         return string.IsNullOrEmpty(leaf) ? "KSP2" : leaf;
     }
     
+    // Called directly from dozens of UI property-changed callbacks (renaming an install, toggling a
+    // checkbox, etc.) via Ksp2InstallService, so a transient I/O failure here (AppData briefly
+    // unreachable - a OneDrive redirect, a USB drive, a network share) must never throw back into a
+    // data-binding callback and crash the whole app. Report and swallow instead.
     public void Save()
     {
-        var directory = _fileSystem.Path.GetDirectoryName(Config.StoragePath);
-        if (string.IsNullOrWhiteSpace(directory))
-            throw new InvalidOperationException($"Could not determine config directory from storage path '{Config.StoragePath}'.");
-
-        _fileSystem.Directory.CreateDirectory(directory);
         try
         {
+            var directory = _fileSystem.Path.GetDirectoryName(Config.StoragePath);
+            if (string.IsNullOrWhiteSpace(directory))
+                throw new InvalidOperationException($"Could not determine config directory from storage path '{Config.StoragePath}'.");
+
+            _fileSystem.Directory.CreateDirectory(directory);
             _fileSystem.File.WriteAllText(Config.StoragePath, JsonSerializer.Serialize(Config, StorageOptions));
             _log.Info($"Launcher config saved to {Config.StoragePath}");
         }
         catch (Exception ex)
         {
             _log.Error($"Failed to save launcher config to {Config.StoragePath}", ex);
-            throw;
+            ReportSaveFailure(ex);
+        }
+    }
+
+    private void ReportSaveFailure(Exception ex)
+    {
+        if (_showingSaveFailureDialog) return;
+        _showingSaveFailureDialog = true;
+        try
+        {
+            Dispatcher.UIThread.Post(async () =>
+            {
+                try
+                {
+                    await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Save Settings",
+                        $"Your changes could not be saved: {ex.Message}\nThey may be lost if you close the launcher. " +
+                        $"Check that {Config.StoragePath} is writable and try again.",
+                        ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+                }
+                finally
+                {
+                    _showingSaveFailureDialog = false;
+                }
+            });
+        }
+        catch (Exception dispatchEx)
+        {
+            _log.Error("Could not show save-failure dialog.", dispatchEx);
+            _showingSaveFailureDialog = false;
         }
     }
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -230,22 +230,45 @@ public partial class HomeTabViewModel : ViewModelBase
                 FileName = $"steam://rungameid/{appId}",
                 UseShellExecute = true,
             };
-            Process.Start(startInfo);
+            try
+            {
+                Process.Start(startInfo);
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Failed to launch through Steam.", ex);
+                await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Launch",
+                    $"Couldn't open Steam: {ex.Message}\nMake sure Steam is installed and try again.",
+                    ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+            }
             return;
         }
 
         MainButtonEnabled = false;
-        using Process process = new();
-        process.StartInfo.FileName = _ksp2InstallService.Ksp2.ExePath;
-        process.StartInfo.WorkingDirectory = _ksp2InstallService.Ksp2.InstallDir;
-        var launchArgs = activeEntry.LaunchArguments;
-        if (!string.IsNullOrWhiteSpace(launchArgs))
+        try
         {
-            process.StartInfo.Arguments = launchArgs;
+            using Process process = new();
+            process.StartInfo.FileName = _ksp2InstallService.Ksp2.ExePath;
+            process.StartInfo.WorkingDirectory = _ksp2InstallService.Ksp2.InstallDir;
+            var launchArgs = activeEntry.LaunchArguments;
+            if (!string.IsNullOrWhiteSpace(launchArgs))
+            {
+                process.StartInfo.Arguments = launchArgs;
+            }
+            process.Start();
+            await process.WaitForExitAsync();
         }
-        process.Start();
-        await process.WaitForExitAsync();
-        MainButtonEnabled = true;
+        catch (Exception ex)
+        {
+            _log.Error("Failed to launch KSP2.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Launch",
+                $"Couldn't start the game: {ex.Message}\nIt may have been moved, removed, or blocked by antivirus software.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+        }
+        finally
+        {
+            MainButtonEnabled = true;
+        }
     }
 
     [RelayCommand]

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -129,9 +129,19 @@ public partial class MainWindowViewModel : ViewModelBase
 
         timer.Tick += async (sender, args) =>
         {
-            if (!await _updateService.CheckAndPerformUpdateAsync()) HomeTab.DisableInstallation();
+            try
+            {
+                if (!await _updateService.CheckAndPerformUpdateAsync()) HomeTab.DisableInstallation();
+            }
+            catch (Exception ex)
+            {
+                // This is an async void-shaped event handler (DispatcherTimer.Tick), so an unhandled
+                // exception here would crash the whole app on a background tick unrelated to anything
+                // the user just did.
+                _log.Error("Periodic update check failed unexpectedly.", ex);
+            }
         };
-        
+
         timer.Start();
     }
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -25,6 +25,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     private readonly HomeTabViewModel _homeTabViewModel;
     private readonly IAssemblyService _assemblyService;
     private readonly IMessageBoxService _messageBoxService;
+    private readonly ILogService _log;
 
     public ObservableCollection<Ksp2InstallRowViewModel> Installs { get; } = [];
     public bool ChannelsLoaded = false;
@@ -61,7 +62,8 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     public SettingsTabViewModel(IFileSystem fileSystem, ICacheService cacheService, ILauncherConfigService launcherConfigService,
         IKsp2InstallService ksp2InstallService,
-        ITabNavigatorService tabNavigatorService, HomeTabViewModel homeTabViewModel, IAssemblyService assemblyService, IMessageBoxService messageBoxService)
+        ITabNavigatorService tabNavigatorService, HomeTabViewModel homeTabViewModel, IAssemblyService assemblyService,
+        IMessageBoxService messageBoxService, ILogService log)
     {
         _fileSystem = fileSystem;
         _cacheService = cacheService;
@@ -71,6 +73,7 @@ public partial class SettingsTabViewModel : ViewModelBase
         _homeTabViewModel = homeTabViewModel;
         _assemblyService = assemblyService;
         _messageBoxService = messageBoxService;
+        _log = log;
 
         _ksp2InstallService.InstallsChanged += (_, _) => RebuildInstalls();
         _ksp2InstallService.ActiveInstallChanged += (_, _) => SyncSelectedInstall();
@@ -134,7 +137,18 @@ public partial class SettingsTabViewModel : ViewModelBase
     [RelayCommand]
     public async Task AddInstall()
     {
-        var chosenPath = await DoOpenFilePickerAsync();
+        IStorageFile? chosenPath;
+        try
+        {
+            chosenPath = await DoOpenFilePickerAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Failed to open the file picker for adding an install.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
         if (chosenPath is null) return;
 
         var path = chosenPath.Path.LocalPath;
@@ -159,7 +173,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     {
         if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop ||
             desktop.MainWindow?.StorageProvider is not { } provider)
-            throw new NullReferenceException("Missing StorageProvider instance.");
+            throw new InvalidOperationException("Could not access the file picker (no active window).");
 
         IStorageFolder? startFolder = null;
         var lastKnownPath = _ksp2InstallService.ActiveEntry?.ExePath;
@@ -201,7 +215,18 @@ public partial class SettingsTabViewModel : ViewModelBase
             ButtonEnum.YesNo, windowStartupLocation:WindowStartupLocation.CenterOwner);
         if (result != ButtonResult.Yes) return;
 
-        _cacheService.RecursivelyRestoreCache(installDir);
+        try
+        {
+            _cacheService.RecursivelyRestoreCache(installDir);
+        }
+        catch (Exception ex)
+        {
+            _log.Error($"Failed to uninstall Redux from {installDir}.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't uninstall Redux: {ex.Message}",
+                windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
 
         _ksp2InstallService.TryLoadKsp2Install();
         await _homeTabViewModel.UpdateVersionsList();
@@ -212,7 +237,18 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     public async Task InstallFromPatchFile()
     {
-        var chosenPath = await DoOpenPatchFilePickerAsync();
+        IStorageFile? chosenPath;
+        try
+        {
+            chosenPath = await DoOpenPatchFilePickerAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Failed to open the file picker for a patch file.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
 
         if (chosenPath is null) return;
 
@@ -226,7 +262,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     {
         if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop ||
             desktop.MainWindow?.StorageProvider is not { } provider)
-            throw new NullReferenceException("Missing StorageProvider instance.");
+            throw new InvalidOperationException("Could not access the file picker (no active window).");
         var startFolder = await provider.TryGetWellKnownFolderAsync(WellKnownFolder.Downloads);
 
         var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions()


### PR DESCRIPTION
## Summary
Batch 1/6 of the v0.2.0 reliability pass: crashes and silent total failures that were reachable in normal use.

- **Saving the config threw unguarded from more than a dozen UI actions** - `LauncherConfigService.Save()` catches its own I/O failures and reports them via dialog instead of throwing back into ~a dozen UI property-changed callbacks (renaming an install, toggling a checkbox, adding/removing an install).
- **Clicking Launch had no failure handling at all** - `LaunchGame` guards both the Steam and direct-exe `Process.Start` calls; the Launch button is always re-enabled afterward.
- **Nothing caught a failure while the app wired itself up** - App startup wraps DI container construction in try/catch (a failure there, including a config `Save()` during first run, previously happened before the logger or any exception handler existed). Falls back to a dependency-free native Win32 message box plus a `bootstrap.log` entry.
- **Uninstall could crash instead of reporting failure** - Uninstall Redux reports a failed cache restore instead of crashing.
- **A file-picker flow could throw a raw NullReferenceException** - The Settings file-picker flows no longer throw a bare `NullReferenceException` when the storage provider is unexpectedly unavailable.
- **The periodic update-check timer could crash a running session** - The tick handler is wrapped in try/catch, since it's an async-void-shaped `DispatcherTimer` callback that could otherwise crash a running session.
