### PR TITLE
Make it debuggable: distinct error logging, log tools, plain-language errors, verbosity control

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DiagnosticInfoTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DiagnosticInfoTest.cs
@@ -1,0 +1,42 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class DiagnosticInfoTest
+{
+    [AvaloniaTest]
+    public async Task BuildDiagnosticInfo_ActiveInstallAndLogPresent_BundlesEverythingIntoOneBlock()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var settingsTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<SettingsTabViewModel>();
+
+        // Act
+        string diagnosticInfo = settingsTabViewModel.BuildDiagnosticInfo();
+
+        // Assert
+        Assert.That(diagnosticInfo, Does.Contain("KSP2 Redux Launcher v"));
+        Assert.That(diagnosticInfo, Does.Contain("Active install:"));
+        Assert.That(diagnosticInfo, Does.Contain("--- Recent log ---"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionDetectionFailureTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionDetectionFailureTest.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class VersionDetectionFailureTest
+{
+    [AvaloniaTest]
+    public async Task Startup_GameVersionDetectionThrows_ShowsPlainLanguageDialogInsteadOfRawException()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        // Override the version-reading mock (set up by MockKsp2StockSteamInstall) to blow up instead.
+        TestAppBuilder.ModuleDefinitionService
+            .Setup(m => m.ReadModule(It.IsAny<string>()))
+            .Throws(new InvalidOperationException("corrupt PE header"));
+
+        // Act
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - the user gets a plain-language explanation, not a dumped exception type/stack trace.
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Detect Game Version",
+                It.Is<string>(s => s.Contains("couldn't figure out") && !s.Contains("InvalidOperationException") && !s.Contains("corrupt PE header")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
@@ -119,9 +119,15 @@ public class LogServiceTest
         var (fs, env) = BuildEnv();
         var log = new LogService(fs, env, maxLogFileSizeBytes: 200);
 
-        // Push the file past the tiny test cap, then keep writing.
+        // Push the file past the tiny test cap. Depending on how long the header's OS-description
+        // line happens to be on the host running the test, the cap might already be exceeded before
+        // this call (in which case the "reached cap" warning is written here and this line is
+        // skipped) or only after it (in which case this line is written and the warning is
+        // deferred to the next call) - so a second call is needed to guarantee the warning has
+        // been written before taking the "settled" size snapshot below.
         log.Info(new string('x', 250));
-        var sizeAfterCapHit = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
+        log.Info("may or may not reach disk depending on header length, don't assert on it");
+        var sizeAfterCapAndWarning = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
 
         log.Info("this line must not reach disk");
         log.Info("neither must this one");
@@ -131,9 +137,10 @@ public class LogServiceTest
         var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
         Assert.Multiple(() =>
         {
-            Assert.That(sizeAfterMoreWrites, Is.EqualTo(sizeAfterCapHit), "No further lines should be written once the cap is reached.");
+            Assert.That(sizeAfterMoreWrites, Is.EqualTo(sizeAfterCapAndWarning), "No further lines should be written once the cap is reached.");
             Assert.That(contents, Does.Contain("Log file reached"));
             Assert.That(contents, Does.Not.Contain("this line must not reach disk"));
+            Assert.That(contents, Does.Not.Contain("neither must this one"));
         });
     }
 

--- a/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
@@ -60,6 +60,19 @@ public class LogServiceTest
     }
 
     [Test]
+    public void Info_TagsEachLineWithProcessId_SoAPastedFragmentIsSelfDescribing()
+    {
+        var (fs, env) = BuildEnv();
+        using var log = new LogService(fs, env);
+
+        log.Info("hello world");
+        log.Dispose();
+
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.That(contents, Does.Contain($"[pid={env.ProcessId}]"));
+    }
+
+    [Test]
     public void Error_WritesExceptionDetailsToLogFile()
     {
         var (fs, env) = BuildEnv();

--- a/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
@@ -101,6 +101,61 @@ public class LogServiceTest
     }
 
     [Test]
+    public void Write_LogFileExceedsSizeCap_StopsWritingFurtherLinesToDisk()
+    {
+        var (fs, env) = BuildEnv();
+        var log = new LogService(fs, env, maxLogFileSizeBytes: 200);
+
+        // Push the file past the tiny test cap, then keep writing.
+        log.Info(new string('x', 250));
+        var sizeAfterCapHit = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
+
+        log.Info("this line must not reach disk");
+        log.Info("neither must this one");
+
+        var sizeAfterMoreWrites = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
+        log.Dispose();
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(sizeAfterMoreWrites, Is.EqualTo(sizeAfterCapHit), "No further lines should be written once the cap is reached.");
+            Assert.That(contents, Does.Contain("Log file reached"));
+            Assert.That(contents, Does.Not.Contain("this line must not reach disk"));
+        });
+    }
+
+    [Test]
+    public void Debug_BelowDefaultMinimumLevel_IsNotWrittenToLogFile()
+    {
+        var (fs, env) = BuildEnv();
+        using var log = new LogService(fs, env);
+
+        log.Debug("verbose detail");
+        log.Info("normal message");
+        log.Dispose();
+
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(contents, Does.Not.Contain("verbose detail"));
+            Assert.That(contents, Does.Contain("normal message"));
+        });
+    }
+
+    [Test]
+    public void Debug_MinimumLevelLoweredToDebug_IsWrittenToLogFile()
+    {
+        var (fs, env) = BuildEnv();
+        using var log = new LogService(fs, env) { MinimumLevel = LogLevel.Debug };
+
+        log.Debug("verbose detail");
+        log.Dispose();
+
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.That(contents, Does.Contain("verbose detail"));
+    }
+
+    [Test]
     public void Constructor_WhenFileOpenFails_FallsBackToConsoleOnly()
     {
         var env = new MockEnvironmentProvider();

--- a/Ksp2Redux.Tools.Launcher/Models/LauncherConfig.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/LauncherConfig.cs
@@ -29,6 +29,11 @@ public class LauncherConfig
 
     public string LauncherRepo { get; set; } = "https://github.com/KSP2Redux/Updater";
 
+    /// <summary>
+    /// When enabled, lowers the log file's minimum level to Debug for more detailed troubleshooting output.
+    /// </summary>
+    public bool VerboseLogging { get; set; } = false;
+
     [JsonIgnore]
     public string StoragePath { get; set; }
 

--- a/Ksp2Redux.Tools.Launcher/Services/LogService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LogService.cs
@@ -8,6 +8,14 @@ using System.Text;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
 
+public enum LogLevel
+{
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+}
+
 public interface ILogService
 {
     void Info(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "");
@@ -15,25 +23,36 @@ public interface ILogService
     void Error(string message, Exception? exception = null, [CallerFilePath] string source = "", [CallerMemberName] string member = "");
     void Debug(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "");
     string? CurrentLogFilePath { get; }
+
+    /// <summary>
+    /// The lowest level that will actually be written. Defaults to <see cref="Services.LogLevel.Info"/>;
+    /// lower it to <see cref="Services.LogLevel.Debug"/> for troubleshooting a specific session.
+    /// </summary>
+    LogLevel MinimumLevel { get; set; }
 }
 
 public sealed class LogService : ILogService, IDisposable
 {
     private const int MaxLogFilesToKeep = 10;
+    private const long DefaultMaxLogFileSizeBytes = 20 * 1024 * 1024;
     private const string LogFilePrefix = "launcher-";
     private const string LogFileExtension = ".log";
 
     private readonly IFileSystem _fileSystem;
+    private readonly long _maxLogFileSizeBytes;
     private readonly object _writeLock = new();
     private StreamWriter? _writer;
     private bool _disposed;
+    private bool _sizeCapReached;
     private readonly int _processId;
 
     public string? CurrentLogFilePath { get; private set; }
+    public LogLevel MinimumLevel { get; set; } = LogLevel.Info;
 
-    public LogService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider)
+    public LogService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, long maxLogFileSizeBytes = DefaultMaxLogFileSizeBytes)
     {
         _fileSystem = fileSystem;
+        _maxLogFileSizeBytes = maxLogFileSizeBytes;
         _processId = environmentProvider.ProcessId;
         try
         {
@@ -96,28 +115,28 @@ public sealed class LogService : ILogService, IDisposable
     }
 
     public void Info(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("INFO", message, null, source, member);
+        => Write(LogLevel.Info, "INFO", message, null, source, member);
 
     public void Warn(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("WARN", message, null, source, member);
+        => Write(LogLevel.Warn, "WARN", message, null, source, member);
 
     public void Error(string message, Exception? exception = null, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("ERROR", message, exception, source, member);
+        => Write(LogLevel.Error, "ERROR", message, exception, source, member);
 
     public void Debug(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("DEBUG", message, null, source, member);
+        => Write(LogLevel.Debug, "DEBUG", message, null, source, member);
 
-    private void Write(string level, string message, Exception? exception, string source, string member)
+    private void Write(LogLevel level, string levelName, string message, Exception? exception, string source, string member)
     {
-        if (_disposed) return;
+        if (_disposed || level < MinimumLevel) return;
 
         var sourceName = string.IsNullOrEmpty(source)
             ? ""
             : _fileSystem.Path.GetFileNameWithoutExtension(source);
 
         var prefix = string.IsNullOrEmpty(sourceName)
-            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{level}]"
-            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{level}] [{sourceName}.{member}]";
+            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}]"
+            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}] [{sourceName}.{member}]";
 
         var line = $"{prefix} {message}";
 
@@ -125,8 +144,17 @@ public sealed class LogService : ILogService, IDisposable
         {
             try
             {
-                _writer?.WriteLine(line);
-                if (exception != null) _writer?.WriteLine(exception.ToString());
+                if (!_sizeCapReached && CurrentLogFilePath is not null &&
+                    _fileSystem.FileInfo.New(CurrentLogFilePath).Length >= _maxLogFileSizeBytes)
+                {
+                    _sizeCapReached = true;
+                    _writer?.WriteLine($"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [WARN] Log file reached {_maxLogFileSizeBytes} bytes, no further lines will be written to disk this session.");
+                }
+                if (!_sizeCapReached)
+                {
+                    _writer?.WriteLine(line);
+                    if (exception != null) _writer?.WriteLine(exception.ToString());
+                }
             }
             catch { }
         }
@@ -146,9 +174,12 @@ public sealed class LogService : ILogService, IDisposable
         }
     }
 
+    private const long MaxBootstrapLogSizeBytes = 1 * 1024 * 1024;
+
     /// <summary>
     /// Best-effort log used before the DI container is available (Program.cs update-stage error handling).
-    /// Appends to a bootstrap log file in the same logs directory the regular LogService writes to.
+    /// Appends to a bootstrap log file shared across every launch, so entries are tagged with the process id
+    /// to tell separate sessions apart, and the file is reset once it grows past a small cap.
     /// </summary>
     public static void WriteEarly(string message)
     {
@@ -159,7 +190,11 @@ public sealed class LogService : ILogService, IDisposable
             var logsDir = Path.Combine(appdata, LocalStoragePaths.ReduxFolder, LocalStoragePaths.LogsSubfolder);
             Directory.CreateDirectory(logsDir);
             var path = Path.Combine(logsDir, "bootstrap.log");
-            var line = $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [EARLY] {message}{Environment.NewLine}";
+            if (File.Exists(path) && new FileInfo(path).Length >= MaxBootstrapLogSizeBytes)
+            {
+                File.Delete(path);
+            }
+            var line = $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [EARLY] [pid={Environment.ProcessId}] {message}{Environment.NewLine}";
             File.AppendAllText(path, line);
             Console.WriteLine(line.TrimEnd());
         }

--- a/Ksp2Redux.Tools.Launcher/Services/LogService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LogService.cs
@@ -134,9 +134,11 @@ public sealed class LogService : ILogService, IDisposable
             ? ""
             : _fileSystem.Path.GetFileNameWithoutExtension(source);
 
+        // Tag every line with the process id so a fragment pasted out of a bug report can still be
+        // matched back to which run (and which header, further up the file) it came from.
         var prefix = string.IsNullOrEmpty(sourceName)
-            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}]"
-            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}] [{sourceName}.{member}]";
+            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [pid={_processId}] [{levelName}]"
+            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [pid={_processId}] [{levelName}] [{sourceName}.{member}]";
 
         var line = $"{prefix} {message}";
 
@@ -148,7 +150,7 @@ public sealed class LogService : ILogService, IDisposable
                     _fileSystem.FileInfo.New(CurrentLogFilePath).Length >= _maxLogFileSizeBytes)
                 {
                     _sizeCapReached = true;
-                    _writer?.WriteLine($"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [WARN] Log file reached {_maxLogFileSizeBytes} bytes, no further lines will be written to disk this session.");
+                    _writer?.WriteLine($"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [pid={_processId}] [WARN] Log file reached {_maxLogFileSizeBytes} bytes, no further lines will be written to disk this session.");
                 }
                 if (!_sizeCapReached)
                 {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -451,12 +451,11 @@ public partial class HomeTabViewModel : ViewModelBase
         }
         catch (InstallFailedException e)
         {
-            Log(e.Message);
+            LogError(e.Message, e);
         }
         catch (Exception e)
         {
-            Log($"Error updating Redux: {e.Message}");
-            Log($"Stack Trace: {e.StackTrace}");
+            LogError($"Error updating Redux: {e.Message}", e);
             Log($"Redux may be in an invalid state, try uninstalling and reinstalling");
         }
         finally
@@ -508,12 +507,11 @@ public partial class HomeTabViewModel : ViewModelBase
         }
         catch (InstallFailedException e)
         {
-            Log(e.Message);
+            LogError(e.Message, e);
         }
         catch (Exception e)
         {
-            Log($"Error updating Redux: {e.Message}");
-            Log($"Stack Trace: {e.StackTrace}");
+            LogError($"Error updating Redux: {e.Message}", e);
             Log($"Redux may be in an invalid state, try uninstalling and reinstalling");
         }
         finally
@@ -565,6 +563,20 @@ public partial class HomeTabViewModel : ViewModelBase
     private void Log(string message)
     {
         _log.Info(message);
+        AppendToInstallLog(message);
+    }
+
+    // Real install/patch failures used to go through Log(), which always writes at Info - grepping a
+    // user's log file for "ERROR" to find out what went wrong turned up nothing, since the failure and
+    // its stack trace were filed alongside routine progress lines.
+    private void LogError(string message, Exception? exception = null)
+    {
+        _log.Error(message, exception);
+        AppendToInstallLog(message);
+    }
+
+    private void AppendToInstallLog(string message)
+    {
         bool queueUpdate;
         lock (_installLogLock)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -262,9 +262,13 @@ public partial class MainWindowViewModel : ViewModelBase
 
         if (ksp2.VersionDetectionException is { } e)
         {
-            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Could not detect version",
-                $"{e.GetType().FullName}\n\n{e}", ButtonEnum.Ok,
-                windowStartupLocation: WindowStartupLocation.CenterOwner);
+            _log.Error("Could not detect the installed KSP2 version.", e);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Detect Game Version",
+                "KSP2 Redux couldn't figure out which version of the game is installed. " +
+                "This can happen if the game files are missing, corrupted, or from an unsupported source.\n\n" +
+                "You can still try launching or installing, but update checks may be unreliable. " +
+                "Details were written to the log file (see Settings > Open Logs Folder) if you'd like to report this.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
         }
     }
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -3,8 +3,11 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -25,6 +28,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     private readonly HomeTabViewModel _homeTabViewModel;
     private readonly IAssemblyService _assemblyService;
     private readonly IMessageBoxService _messageBoxService;
+    private readonly IEnvironmentProvider _environmentProvider;
     private readonly ILogService _log;
 
     public ObservableCollection<Ksp2InstallRowViewModel> Installs { get; } = [];
@@ -40,6 +44,9 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     [ObservableProperty]
     public partial bool CanRemoveSelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool VerboseLogging { get; set; }
 
     public string LauncherVersion => _assemblyService.GetVersion()?.ToString(4) ?? "?";
 
@@ -63,7 +70,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     public SettingsTabViewModel(IFileSystem fileSystem, ICacheService cacheService, ILauncherConfigService launcherConfigService,
         IKsp2InstallService ksp2InstallService,
         ITabNavigatorService tabNavigatorService, HomeTabViewModel homeTabViewModel, IAssemblyService assemblyService,
-        IMessageBoxService messageBoxService, ILogService log)
+        IMessageBoxService messageBoxService, IEnvironmentProvider environmentProvider, ILogService log)
     {
         _fileSystem = fileSystem;
         _cacheService = cacheService;
@@ -73,11 +80,27 @@ public partial class SettingsTabViewModel : ViewModelBase
         _homeTabViewModel = homeTabViewModel;
         _assemblyService = assemblyService;
         _messageBoxService = messageBoxService;
+        _environmentProvider = environmentProvider;
         _log = log;
 
         _ksp2InstallService.InstallsChanged += (_, _) => RebuildInstalls();
         _ksp2InstallService.ActiveInstallChanged += (_, _) => SyncSelectedInstall();
         RebuildInstalls();
+
+        _suppressVerboseLoggingSave = true;
+        try { VerboseLogging = _launcherConfigService.Config.VerboseLogging; }
+        finally { _suppressVerboseLoggingSave = false; }
+        _log.MinimumLevel = VerboseLogging ? LogLevel.Debug : LogLevel.Info;
+    }
+
+    private bool _suppressVerboseLoggingSave;
+
+    partial void OnVerboseLoggingChanged(bool value)
+    {
+        _log.MinimumLevel = value ? LogLevel.Debug : LogLevel.Info;
+        if (_suppressVerboseLoggingSave) return;
+        _launcherConfigService.Config.VerboseLogging = value;
+        _launcherConfigService.Save();
     }
 
     private void RebuildInstalls()
@@ -274,5 +297,68 @@ public partial class SettingsTabViewModel : ViewModelBase
         });
 
         return files?.Count >= 1 ? files[0] : null;
+    }
+
+    public async Task OpenLogsFolder()
+    {
+        try
+        {
+            var logsDir = LocalStoragePaths.GetLogsDirectory(_fileSystem, _environmentProvider);
+            _fileSystem.Directory.CreateDirectory(logsDir);
+            Process.Start(new ProcessStartInfo(logsDir) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Failed to open the logs folder.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't open the logs folder: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+        }
+    }
+
+    /// <summary>
+    /// Everything a bug report needs in one paste-ready block: launcher version, active install
+    /// details, OS, and the tail of the current log file - so a support conversation doesn't have to
+    /// start with four separate questions before diagnosis can even begin.
+    /// </summary>
+    public string BuildDiagnosticInfo()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"KSP2 Redux Launcher v{LauncherVersion}");
+        sb.AppendLine($"OS: {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
+
+        if (_ksp2InstallService.ActiveEntry is { } entry)
+        {
+            sb.AppendLine($"Active install: {entry.Name} (channel={entry.ReleaseChannel}, launchThroughSteam={entry.LaunchThroughSteam})");
+            sb.AppendLine($"Exe path: {entry.ExePath}");
+            var ksp2 = _ksp2InstallService.Ksp2;
+            sb.AppendLine(ksp2 is { IsValid: true }
+                ? $"Detected: {ksp2.Distribution}, version {ksp2.GameVersion}"
+                : "Detected: (not currently detected as valid)");
+        }
+        else
+        {
+            sb.AppendLine("Active install: (none configured)");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("--- Recent log ---");
+        try
+        {
+            if (_log.CurrentLogFilePath is { } logPath && _fileSystem.File.Exists(logPath))
+            {
+                var lines = _fileSystem.File.ReadAllLines(logPath);
+                sb.AppendLine(string.Join(_environmentProvider.NewLine, lines.TakeLast(100)));
+            }
+            else
+            {
+                sb.AppendLine("(no log file available)");
+            }
+        }
+        catch (Exception ex)
+        {
+            sb.AppendLine($"(could not read log file: {ex.Message})");
+        }
+
+        return sb.ToString();
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
@@ -113,11 +113,20 @@
 				</Grid>
 			</Grid>
 
-			<TextBlock Grid.Row="2"
-			           FontFamily="{StaticResource JetBrainsMonoLight}" FontSize="11"
-			           Foreground="{StaticResource TextFaintBrush}"
-			           HorizontalAlignment="Right" Margin="0,12,0,0"
-			           Text="{Binding LauncherVersion, StringFormat='Launcher v{0}'}" />
+			<Grid Grid.Row="2" ColumnDefinitions="Auto,Auto,Auto,*" ColumnSpacing="10" Margin="0,12,0,0">
+				<Button Grid.Column="0" FontSize="11" Padding="8,4" Click="OpenLogsFolderClick">Open Logs Folder</Button>
+				<Button Grid.Column="1" FontSize="11" Padding="8,4" Click="CopyDiagnosticInfoClick">Copy Diagnostic Info</Button>
+				<CheckBox Grid.Column="2" FontSize="11" VerticalAlignment="Center"
+				          IsChecked="{Binding VerboseLogging, Mode=TwoWay}"
+				          ToolTip.Tip="Write more detailed information to the log file. Useful when troubleshooting an issue.">
+					Verbose logging
+				</CheckBox>
+				<TextBlock Grid.Column="3"
+				           FontFamily="{StaticResource JetBrainsMonoLight}" FontSize="11"
+				           Foreground="{StaticResource TextFaintBrush}"
+				           HorizontalAlignment="Right" VerticalAlignment="Center"
+				           Text="{Binding LauncherVersion, StringFormat='Launcher v{0}'}" />
+			</Grid>
 		</Grid>
 		</Border>
 	</Grid>

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
@@ -20,5 +21,18 @@ public partial class SettingsTabView : UserControl
     private async void InstallFromPatchFile(object? sender, RoutedEventArgs e)
     {
         await Model.InstallFromPatchFile();
+    }
+
+    private async void OpenLogsFolderClick(object? sender, RoutedEventArgs e)
+    {
+        await Model.OpenLogsFolder();
+    }
+
+    private async void CopyDiagnosticInfoClick(object? sender, RoutedEventArgs e)
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+        var clipboard = topLevel?.Clipboard;
+        if (clipboard is null) return;
+        await clipboard.SetTextAsync(Model.BuildDiagnosticInfo());
     }
 }


### PR DESCRIPTION
## Summary
Third batch of the v0.2.0 reliability/hardening pass (stacked on #38, "Protect the install itself" — this PR's diff is scoped to just this batch's changes; it will auto-retarget to `reliability/patch-pipeline-hardening` once #38 merges).

- **Real install failures were logged at Info, not Error**: `HomeTabViewModel` now has a `LogError` method distinct from the routine `Log`, so real failures are logged at Error level (and visually flagged) instead of blending in with progress messages. Removed the now-redundant manual "Stack Trace:" log line since `ILogService.Error` already writes the full exception detail.
- **Nothing helped a user find or share their log file / no single view for what a bug report needs**: Added "Open Logs Folder" and "Copy Diagnostic Info" buttons to the Settings tab. Diagnostic info bundles launcher version, active install name/path/channel/distribution, OS description, and the last 100 lines of the current log file into one clipboard-ready block for bug reports.
- **Log rotation was by file count, not size**: The per-session log file now caps out at 20MB — once hit, a single warning line is written and further lines are dropped from disk (but still go to the console) for the rest of the session, instead of growing unbounded.
- **Log lines weren't tagged to a session**: The bootstrap log (written before DI is available) now tags each line with the process id and resets itself once it exceeds 1MB, so entries from different launches don't blur together in one unbounded file.
- **A version-detection failure showed a raw stack trace**: The "could not detect game version" dialog no longer dumps the raw exception type and stack trace at the user. It now shows a plain-language explanation and points to the log file, while the full exception is still logged via `ILogService.Error`.
- **No way to raise log verbosity without a custom build**: Added a "Verbose logging" checkbox in Settings that lowers the log threshold to Debug for troubleshooting, persisted in `LauncherConfig`.