### PR TITLE
Harden Settings input: validate, confirm, and guard re-entrancy

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SettingsInputHardeningTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SettingsInputHardeningTest.cs
@@ -1,0 +1,94 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class SettingsInputHardeningTest
+{
+    private static async Task<SettingsTabViewModel> BootstrapAsync()
+    {
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return TestAppBuilder.ServiceProvider.GetRequiredService<SettingsTabViewModel>();
+    }
+
+    [AvaloniaTest]
+    public async Task RemoveSelectedInstall_Declined_KeepsTheInstall()
+    {
+        // Arrange
+        var settingsTabViewModel = await BootstrapAsync();
+        var ksp2InstallService = TestAppBuilder.ServiceProvider.GetRequiredService<IKsp2InstallService>();
+        ksp2InstallService.AddInstall(@"C:\Other\KSP2_x64.exe", "Second install");
+
+        TestAppBuilder.MessageBoxService.Setup(m => m.ShowMessageBoxAsOwnedAsync(
+                "Confirm", It.IsAny<string>(), It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()))
+            .ReturnsAsync(ButtonResult.No);
+
+        var countBefore = ksp2InstallService.Entries.Count;
+
+        // Act
+        await settingsTabViewModel.RemoveSelectedInstallCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.That(ksp2InstallService.Entries, Has.Count.EqualTo(countBefore));
+    }
+
+    [AvaloniaTest]
+    public async Task RemoveSelectedInstall_Confirmed_RemovesTheInstall()
+    {
+        // Arrange
+        var settingsTabViewModel = await BootstrapAsync();
+        var ksp2InstallService = TestAppBuilder.ServiceProvider.GetRequiredService<IKsp2InstallService>();
+        ksp2InstallService.AddInstall(@"C:\Other\KSP2_x64.exe", "Second install");
+
+        TestAppBuilder.MessageBoxService.Setup(m => m.ShowMessageBoxAsOwnedAsync(
+                "Confirm", It.IsAny<string>(), It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()))
+            .ReturnsAsync(ButtonResult.Yes);
+
+        var countBefore = ksp2InstallService.Entries.Count;
+
+        // Act
+        await settingsTabViewModel.RemoveSelectedInstallCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.That(ksp2InstallService.Entries, Has.Count.EqualTo(countBefore - 1));
+    }
+
+    [AvaloniaTest]
+    public async Task AddInstall_AlreadyInProgress_ReturnsWithoutTouchingTheFilePicker()
+    {
+        // Arrange - simulate a fast double-click by marking the flow as already in progress.
+        var settingsTabViewModel = await BootstrapAsync();
+        settingsTabViewModel.IsAddingInstall = true;
+
+        // Act
+        await settingsTabViewModel.AddInstallCommand.ExecuteAsync(null);
+
+        // Assert - the re-entrancy guard returned early, so the file-picker failure path
+        // (which would show this dialog, since there's no real window in this test) never ran.
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Error!", It.Is<string>(s => s.Contains("file picker")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallRowViewModelValidationTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallRowViewModelValidationTest.cs
@@ -1,0 +1,83 @@
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class Ksp2InstallRowViewModelValidationTest
+{
+    private const string ValidExePath = @"C:\Games\Ksp2\KSP2_x64.exe";
+
+    private static (Ksp2InstallRowViewModel Row, MockFileSystem FileSystem) MakeRow(string exePath, string steamAppId)
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(@"C:\Games\Ksp2");
+        fs.File.WriteAllBytes(ValidExePath, [0x00]);
+
+        var entry = new Ksp2InstallEntry
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            ExePath = exePath,
+            ReleaseChannel = "beta",
+            SteamAppId = steamAppId,
+        };
+        var ksp2InstallService = new Mock<IKsp2InstallService>();
+        var row = new Ksp2InstallRowViewModel(fs, ksp2InstallService.Object, entry, isActive: true);
+        return (row, fs);
+    }
+
+    [Test]
+    public void ExePath_PointsToRealKsp2Exe_HasNoError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+        Assert.That(row.ExePathError, Is.Null);
+    }
+
+    [Test]
+    public void ExePath_WrongFileName_HasError()
+    {
+        var (row, fs) = MakeRow(ValidExePath, "954850");
+        fs.File.WriteAllBytes(@"C:\Games\Ksp2\NotTheGame.exe", [0x00]);
+
+        row.ExePath = @"C:\Games\Ksp2\NotTheGame.exe";
+
+        Assert.That(row.ExePathError, Does.Contain("KSP2_x64.exe"));
+    }
+
+    [Test]
+    public void ExePath_DoesNotExist_HasError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+
+        row.ExePath = @"C:\Games\Ksp2\Missing\KSP2_x64.exe";
+
+        Assert.That(row.ExePathError, Does.Contain("doesn't exist"));
+    }
+
+    [Test]
+    public void SteamAppId_Numeric_HasNoError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+        Assert.That(row.SteamAppIdError, Is.Null);
+    }
+
+    [Test]
+    public void SteamAppId_Empty_HasNoError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "");
+        Assert.That(row.SteamAppIdError, Is.Null);
+    }
+
+    [Test]
+    public void SteamAppId_NonNumeric_HasError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+
+        row.SteamAppId = "not-a-number";
+
+        Assert.That(row.SteamAppIdError, Does.Contain("numeric"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO.Abstractions;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
@@ -7,6 +9,7 @@ namespace Ksp2Redux.Tools.Launcher.ViewModels.Settings;
 
 public partial class Ksp2InstallRowViewModel : ViewModelBase
 {
+    private readonly IFileSystem _fileSystem;
     private readonly IKsp2InstallService _ksp2InstallService;
     private readonly Ksp2InstallEntry _entry;
 
@@ -17,6 +20,9 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
 
     [ObservableProperty]
     public partial string ExePath { get; set; }
+
+    [ObservableProperty]
+    public partial string? ExePathError { get; set; }
 
     [ObservableProperty]
     public partial string ReleaseChannel { get; set; }
@@ -31,13 +37,17 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
     public partial string SteamAppId { get; set; }
 
     [ObservableProperty]
+    public partial string? SteamAppIdError { get; set; }
+
+    [ObservableProperty]
     public partial string LaunchArguments { get; set; }
 
     [ObservableProperty]
     public partial bool DisableGraphicsJobs { get; set; }
 
-    public Ksp2InstallRowViewModel(IKsp2InstallService ksp2InstallService, Ksp2InstallEntry entry, bool isActive)
+    public Ksp2InstallRowViewModel(IFileSystem fileSystem, IKsp2InstallService ksp2InstallService, Ksp2InstallEntry entry, bool isActive)
     {
+        _fileSystem = fileSystem;
         _ksp2InstallService = ksp2InstallService;
         _entry = entry;
         Name = entry.Name;
@@ -48,10 +58,17 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
         SteamAppId = entry.SteamAppId;
         LaunchArguments = entry.LaunchArguments;
         DisableGraphicsJobs = entry.DisableGraphicsJobs;
+
+        ExePathError = ValidateExePath(ExePath);
+        SteamAppIdError = ValidateSteamAppId(SteamAppId);
     }
 
     partial void OnNameChanged(string value) => _ksp2InstallService.RenameInstall(_entry.Id, value);
-    partial void OnExePathChanged(string value) => _ksp2InstallService.UpdateInstallExePath(_entry.Id, value);
+    partial void OnExePathChanged(string value)
+    {
+        ExePathError = ValidateExePath(value);
+        _ksp2InstallService.UpdateInstallExePath(_entry.Id, value);
+    }
     partial void OnReleaseChannelChanged(string value)
     {
         if (string.IsNullOrEmpty(value)) return;
@@ -72,6 +89,7 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
     partial void OnSteamAppIdChanged(string value)
     {
         var normalized = value?.Trim() ?? "";
+        SteamAppIdError = ValidateSteamAppId(normalized);
         if (_entry.SteamAppId == normalized) return;
         _entry.SteamAppId = normalized;
         _ksp2InstallService.NotifyInstallChanged(_entry.Id);
@@ -87,4 +105,18 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
 
     partial void OnDisableGraphicsJobsChanged(bool value)
         => _ksp2InstallService.UpdateInstallDisableGraphicsJobs(_entry.Id, value);
+
+    private string? ValidateExePath(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "An install path is required.";
+        if (_fileSystem.Path.GetFileName(value) != Ksp2Install.KSP2_EXE_NAME) return $"Path must point to {Ksp2Install.KSP2_EXE_NAME}.";
+        if (!_fileSystem.File.Exists(value)) return "That file doesn't exist.";
+        return null;
+    }
+
+    private static string? ValidateSteamAppId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return value.All(char.IsAsciiDigit) ? null : "Steam App ID must be numeric.";
+    }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -48,6 +48,9 @@ public partial class SettingsTabViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool VerboseLogging { get; set; }
 
+    [ObservableProperty]
+    public partial bool IsAddingInstall { get; set; }
+
     public string LauncherVersion => _assemblyService.GetVersion()?.ToString(4) ?? "?";
 
     private bool _suppressActiveSync;
@@ -123,7 +126,7 @@ public partial class SettingsTabViewModel : ViewModelBase
             Installs.Clear();
             foreach (var entry in entries)
             {
-                Installs.Add(new Ksp2InstallRowViewModel(_ksp2InstallService, entry, entry.Id == activeId));
+                Installs.Add(new Ksp2InstallRowViewModel(_fileSystem, _ksp2InstallService, entry, entry.Id == activeId));
             }
         }
         SyncSelectedInstall();
@@ -160,36 +163,52 @@ public partial class SettingsTabViewModel : ViewModelBase
     [RelayCommand]
     public async Task AddInstall()
     {
-        IStorageFile? chosenPath;
+        if (IsAddingInstall) return;
+        IsAddingInstall = true;
         try
         {
-            chosenPath = await DoOpenFilePickerAsync();
-        }
-        catch (Exception ex)
-        {
-            _log.Error("Failed to open the file picker for adding an install.", ex);
-            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
-                $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
-            return;
-        }
-        if (chosenPath is null) return;
+            IStorageFile? chosenPath;
+            try
+            {
+                chosenPath = await DoOpenFilePickerAsync();
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Failed to open the file picker for adding an install.", ex);
+                await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                    $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+                return;
+            }
+            if (chosenPath is null) return;
 
-        var path = chosenPath.Path.LocalPath;
-        var existing = _ksp2InstallService.Entries.FirstOrDefault(e =>
-            string.Equals(e.ExePath, path, StringComparison.OrdinalIgnoreCase));
-        if (existing is not null)
-        {
-            _ksp2InstallService.SetActiveInstall(existing.Id);
-            return;
+            var path = chosenPath.Path.LocalPath;
+            var existing = _ksp2InstallService.Entries.FirstOrDefault(e =>
+                string.Equals(e.ExePath, path, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null)
+            {
+                _ksp2InstallService.SetActiveInstall(existing.Id);
+                return;
+            }
+            _ksp2InstallService.AddInstall(path);
         }
-        _ksp2InstallService.AddInstall(path);
+        finally
+        {
+            IsAddingInstall = false;
+        }
     }
 
     [RelayCommand]
-    public void RemoveSelectedInstall()
+    public async Task RemoveSelectedInstall()
     {
         if (Installs.Count <= 1) return;
-        if (SelectedInstall is { } row) _ksp2InstallService.RemoveInstall(row.Id);
+        if (SelectedInstall is not { } row) return;
+
+        var result = await _messageBoxService.ShowMessageBoxAsOwnedAsync("Confirm",
+            $"Are you sure you want to remove \"{row.Name}\"? Its name, launch arguments, and Steam settings will be lost.",
+            ButtonEnum.YesNo, windowStartupLocation: WindowStartupLocation.CenterOwner);
+        if (result != ButtonResult.Yes) return;
+
+        _ksp2InstallService.RemoveInstall(row.Id);
     }
 
     public async Task<IStorageFile?> DoOpenFilePickerAsync()

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:settings="clr-namespace:Ksp2Redux.Tools.Launcher.ViewModels.Settings"
+             xmlns:conv="clr-namespace:Avalonia.Data.Converters;assembly=Avalonia.Base"
              x:DataType="settings:SettingsTabViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Ksp2Redux.Tools.Launcher.Views.SettingsTabView"
@@ -23,7 +24,7 @@
 
 			<Grid Grid.Row="1"
 			      ColumnDefinitions="Auto,*"
-			      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+			      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
 			      ColumnSpacing="10" RowSpacing="6">
 
 				<TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center">Editing install</TextBlock>
@@ -39,7 +40,8 @@
 				</ComboBox>
 
 				<StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Spacing="6" HorizontalAlignment="Left">
-					<Button Command="{Binding AddInstallCommand}" ToolTip.Tip="Add a KSP2 install">Add</Button>
+					<Button Command="{Binding AddInstallCommand}" IsEnabled="{Binding !IsAddingInstall}"
+					        ToolTip.Tip="Add a KSP2 install">Add</Button>
 					<Button Classes="danger"
 					        Command="{Binding RemoveSelectedInstallCommand}"
 					        IsEnabled="{Binding CanRemoveSelectedInstall}"
@@ -61,49 +63,57 @@
 				         PlaceholderText="C:\Steam\SteamGames\KSP2\KSP2_x64.exe"
 				         FontFamily="{StaticResource JetBrainsMonoLight}" FontSize="11" />
 
-				<TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="4" Grid.Column="1" FontSize="11" Foreground="{StaticResource DangerBrush}"
+				           IsVisible="{Binding SelectedInstall.ExePathError, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}"
+				           Text="{Binding SelectedInstall.ExePathError}" TextWrapping="Wrap" />
+
+				<TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}">Release channel</TextBlock>
-				<ComboBox Grid.Row="4" Grid.Column="1" HorizontalAlignment="Stretch"
+				<ComboBox Grid.Row="5" Grid.Column="1" HorizontalAlignment="Stretch"
 				          Name="ReleaseChannelSelector"
 				          IsVisible="{Binding HasSelectedInstall}"
 				          MaxDropDownHeight="200"
 				          SelectedValue="{Binding SelectedInstall.ReleaseChannel, Mode=TwoWay}"
 				          ItemsSource="{Binding ValidChannels}" />
 
-				<TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}">Launch through Steam</TextBlock>
-				<CheckBox Grid.Row="5" Grid.Column="1" HorizontalAlignment="Left"
+				<CheckBox Grid.Row="6" Grid.Column="1" HorizontalAlignment="Left"
 				          IsVisible="{Binding HasSelectedInstall}"
 				          IsChecked="{Binding SelectedInstall.LaunchThroughSteam, Mode=TwoWay}" />
 
-				<TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}"
 				           ToolTip.Tip="Override to launch a Steam 'Add a Non-Steam Game' shortcut for KSP2. Leave as 954850 for the normal Steam release.">Steam app id</TextBlock>
-				<TextBox Grid.Row="6" Grid.Column="1" HorizontalAlignment="Stretch"
+				<TextBox Grid.Row="7" Grid.Column="1" HorizontalAlignment="Stretch"
 				         IsVisible="{Binding HasSelectedInstall}"
 				         PlaceholderText="954850"
 				         Text="{Binding SelectedInstall.SteamAppId, Mode=TwoWay}"
 				         IsEnabled="{Binding SelectedInstall.LaunchThroughSteam}" />
 
-				<TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="8" Grid.Column="1" FontSize="11" Foreground="{StaticResource DangerBrush}"
+				           IsVisible="{Binding SelectedInstall.SteamAppIdError, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}"
+				           Text="{Binding SelectedInstall.SteamAppIdError}" TextWrapping="Wrap" />
+
+				<TextBlock Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}"
 				           ToolTip.Tip="Arguments passed to KSP2_x64.exe on launch. Ignored when 'Launch through Steam' is enabled.">Launch arguments</TextBlock>
-				<TextBox Grid.Row="7" Grid.Column="1" HorizontalAlignment="Stretch"
+				<TextBox Grid.Row="9" Grid.Column="1" HorizontalAlignment="Stretch"
 				         IsVisible="{Binding HasSelectedInstall}"
 				         Text="{Binding SelectedInstall.LaunchArguments, Mode=TwoWay}"
 				         IsEnabled="{Binding !SelectedInstall.LaunchThroughSteam}" />
 
-				<TextBlock Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}"
 				           ToolTip.Tip="Sets gfx-enable-gfx-jobs=0 in boot.config. Workaround for crashes on some hardware.">Disable graphics jobs</TextBlock>
-				<CheckBox Grid.Row="8" Grid.Column="1" HorizontalAlignment="Left"
+				<CheckBox Grid.Row="10" Grid.Column="1" HorizontalAlignment="Left"
 				          IsVisible="{Binding HasSelectedInstall}"
 				          IsChecked="{Binding SelectedInstall.DisableGraphicsJobs, Mode=TwoWay}" />
 
-				<Separator Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" Margin="0 4 0 4"
+				<Separator Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2" Margin="0 4 0 4"
 				           IsVisible="{Binding HasSelectedInstall}" />
 
-				<Grid Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2"
+				<Grid Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2"
 				      ColumnDefinitions="*,*" ColumnSpacing="10"
 				      IsVisible="{Binding HasSelectedInstall}">
 					<Button Grid.Column="0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"


### PR DESCRIPTION
## Summary
Fourth batch of the v0.2.0 reliability/hardening pass (stacked on #39, "Make it debuggable" — this PR's diff is scoped to just this batch's changes; it will auto-retarget once #39 merges).

- **Settings fields accepted invalid values with no validation**: The install path and Steam App ID fields in Settings now validate inline instead of persisting whatever was typed. A mistyped exe path or non-numeric App ID used to surface much later as an unrelated "installation not detected" or a Launch button that just did nothing. `Ksp2InstallRowViewModel` now exposes `ExePathError`/`SteamAppIdError`, shown as inline red text under each field.
- **Removing an install had no confirmation**: Removing an install now asks for confirmation (the same Yes/No prompt used for uninstalling), since it permanently discards the install's name, launch arguments, and Steam settings with no way back.
- **Adding an install had no re-entrancy guard**: Adding an install is now guarded against a fast double-click opening two file pickers at once — the Add button disables itself while the flow is in progress.
