### PR TITLE
Community and news polish: safe link launching, stable news identity, resilient parsing

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/CommunityTabViewModelTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/CommunityTabViewModelTest.cs
@@ -1,0 +1,47 @@
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels.Community;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class CommunityTabViewModelTest
+{
+    [Test]
+    public void SelectedNews_IdNoLongerInTheBackingList_FallsBackToEmptyInsteadOfThrowing()
+    {
+        var newsService = new Mock<INewsService>();
+        newsService.Setup(n => n.GetNews("stale-id")).Returns((News?)null);
+        var communityTabViewModel = new CommunityTabViewModel(newsService.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
+
+        communityTabViewModel.SetSelectedNewsId("stale-id");
+
+        Assert.That(communityTabViewModel.SelectedNews.Title, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void NewsVisible_NothingSelected_IsFalse()
+    {
+        var newsService = new Mock<INewsService>();
+        var communityTabViewModel = new CommunityTabViewModel(newsService.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
+
+        Assert.That(communityTabViewModel.NewsVisible, Is.False);
+    }
+
+    [Test]
+    public void SetSelectedNewsId_MatchingId_ShowsThatArticle()
+    {
+        var news = new News { Id = "abc", Title = "Hello" };
+        var newsService = new Mock<INewsService>();
+        newsService.Setup(n => n.GetNews("abc")).Returns(news);
+        var communityTabViewModel = new CommunityTabViewModel(newsService.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
+
+        communityTabViewModel.SetSelectedNewsId("abc");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(communityTabViewModel.NewsVisible, Is.True);
+            Assert.That(communityTabViewModel.SelectedNews.Title, Is.EqualTo("Hello"));
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ExternalLinkTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ExternalLinkTest.cs
@@ -1,0 +1,108 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Community;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class ExternalLinkTest
+{
+    private static async Task<(MainWindowViewModel MainWindowViewModel, TopLevel TopLevel)> BootstrapAsync()
+    {
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        var mainWindowViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>();
+        MainWindow window = new MainWindow { DataContext = mainWindowViewModel };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (mainWindowViewModel, TopLevel.GetTopLevel(window)!);
+    }
+
+    [AvaloniaTest]
+    public async Task LaunchExternalLinkAsync_MalformedUrl_ShowsFeedbackInsteadOfThrowing()
+    {
+        // Arrange
+        var (mainWindowViewModel, topLevel) = await BootstrapAsync();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await mainWindowViewModel.LaunchExternalLinkAsync(topLevel, "not a valid url");
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null, "A malformed link must not throw from the click handler.");
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Open Link", It.IsAny<string>(),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+
+    [AvaloniaTest]
+    public async Task LaunchExternalLinkAsync_RelativeUrl_ShowsFeedbackInsteadOfThrowing()
+    {
+        // Arrange - a link that fails Uri.TryCreate's absolute-URI requirement (e.g. a feed
+        // returning a site-relative path instead of a full URL).
+        var (mainWindowViewModel, topLevel) = await BootstrapAsync();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await mainWindowViewModel.LaunchExternalLinkAsync(topLevel, "/blog/post-1");
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null);
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Open Link", It.IsAny<string>(),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+
+    [AvaloniaTest]
+    public async Task CommunityTab_LaunchExternalLinkAsync_MalformedUrl_ShowsFeedbackInsteadOfThrowing()
+    {
+        // Arrange
+        var (_, topLevel) = await BootstrapAsync();
+        var communityTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<CommunityTabViewModel>();
+
+        // Act - an empty/malformed link, e.g. a news post with no Link, used to reach `new Uri("")`.
+        Exception? thrown = null;
+        try
+        {
+            await communityTabViewModel.LaunchExternalLinkAsync(topLevel, "");
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null);
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Open Link", It.IsAny<string>(),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/NewsServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/NewsServiceTest.cs
@@ -1,0 +1,72 @@
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class NewsServiceTest
+{
+    private static (NewsService Service, Mock<INewsProviderService> Provider, Mock<ILogService> Log) MakeService()
+    {
+        var provider = new Mock<INewsProviderService>();
+        var log = new Mock<ILogService>();
+        return (new NewsService(provider.Object, log.Object), provider, log);
+    }
+
+    [Test]
+    public async Task FetchNews_OneItemMissingPublishDate_SkipsItButKeepsTheRest()
+    {
+        var (service, provider, log) = MakeService();
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed
+        {
+            Items =
+            [
+                new FeedItem { Title = "Good post", Link = "https://a", PublishingDate = new DateTime(2026, 1, 1) },
+                new FeedItem { Title = "Missing date", Link = "https://b", PublishingDate = null },
+                new FeedItem { Title = "Another good post", Link = "https://c", PublishingDate = new DateTime(2026, 1, 2) },
+            ],
+        });
+
+        await service.FetchNews();
+        var news = await service.FindAllNews();
+
+        Assert.That(news.Select(n => n.Title), Is.EquivalentTo(new[] { "Good post", "Another good post" }));
+        log.Verify(l => l.Warn(It.Is<string>(s => s.Contains("Missing date")), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetNews_ByStableId_ReturnsTheSameItemAcrossARefetchThatChangesListLength()
+    {
+        var (service, provider, _) = MakeService();
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed
+        {
+            Items =
+            [
+                new FeedItem { Title = "First", Link = "https://a", PublishingDate = new DateTime(2026, 1, 1) },
+                new FeedItem { Title = "Second", Link = "https://b", PublishingDate = new DateTime(2026, 1, 2) },
+            ],
+        });
+        await service.FetchNews();
+        var secondId = (await service.FindAllNews()).Single(n => n.Title == "Second").Id;
+
+        // Simulate the feed being refetched with a different shape - the old index into the list
+        // would now point somewhere else (or be out of range), but the stable id still resolves.
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed
+        {
+            Items = [new FeedItem { Title = "Second", Link = "https://b", PublishingDate = new DateTime(2026, 1, 2) }],
+        });
+        await service.FetchNews();
+
+        Assert.That(service.GetNews(secondId)?.Title, Is.EqualTo("Second"));
+    }
+
+    [Test]
+    public async Task GetNews_IdNoLongerPresent_ReturnsNullInsteadOfThrowing()
+    {
+        var (service, provider, _) = MakeService();
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        await service.FetchNews();
+
+        Assert.That(service.GetNews("stale-id"), Is.Null);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Models/News.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/News.cs
@@ -4,6 +4,12 @@ namespace Ksp2Redux.Tools.Launcher.Models;
 
 public sealed record News
 {
+    /// <summary>
+    /// Stable identity for this post - defaults to its link (unique per RSS entry) so a post stays
+    /// addressable across refetches, unlike a list index which shifts when the feed changes shape.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
     public string Title { get; init; } = string.Empty;
     public string Content { get; init; } = string.Empty;
     public DateTime Date { get; init; }

--- a/Ksp2Redux.Tools.Launcher/Services/ExternalLinkLauncher.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/ExternalLinkLauncher.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+/// <summary>
+/// Shared behavior for opening a link in the default browser from a view model - validates the URL,
+/// awaits the launch, and reports a failure instead of letting a malformed feed link or a missing
+/// default browser throw from a click handler with nothing shown to the user.
+/// </summary>
+internal static class ExternalLinkLauncher
+{
+    public static async Task LaunchAsync(TopLevel? topLevel, string? url, IMessageBoxService messageBoxService, ILogService log)
+    {
+        if (topLevel is null) return;
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            log.Warn($"Ignored invalid link: {url}");
+            await messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Open Link",
+                "That link doesn't look valid.", windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
+
+        try
+        {
+            await topLevel.Launcher.LaunchUriAsync(uri);
+        }
+        catch (Exception ex)
+        {
+            log.Error($"Failed to open link: {url}", ex);
+            await messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Open Link",
+                $"Couldn't open the link: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+        }
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/NewsService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/NewsService.cs
@@ -10,20 +10,17 @@ namespace Ksp2Redux.Tools.Launcher.Services;
 public interface INewsService
 {
     Task<List<News>> FindAllNews();
-    News GetNews(int id);
-    int GetNewsId(News? news);
+    News? GetNews(string? id);
     Task FetchNews();
 }
 
-public class NewsService(INewsProviderService newsProviderService) : INewsService
+public class NewsService(INewsProviderService newsProviderService, ILogService log) : INewsService
 {
     private List<News> _newsList = new();
-    
+
     public async Task<List<News>> FindAllNews() => await Task.Run(() => _newsList.OrderByDescending(n => n.Date).ToList());
 
-    public News GetNews(int id) => id == -1 ? new News() : _newsList[id];
-    
-    public int GetNewsId(News? news) => news == null ? -1 : _newsList.IndexOf(news);
+    public News? GetNews(string? id) => id is null ? null : _newsList.FirstOrDefault(n => n.Id == id);
 
     public async Task FetchNews()
     {
@@ -35,14 +32,25 @@ public class NewsService(INewsProviderService newsProviderService) : INewsServic
 
     private void LoadNewsFromFeed(Feed rssNewsContent)
     {
-        _newsList = rssNewsContent.Items.Select(item => new News
+        var newsList = new List<News>();
+        foreach (var item in rssNewsContent.Items)
+        {
+            if (item.PublishingDate is not { } date)
             {
+                log.Warn($"Skipping RSS item \"{item.Title}\" - missing or unparseable publish date.");
+                continue;
+            }
+
+            newsList.Add(new News
+            {
+                Id = string.IsNullOrWhiteSpace(item.Link) ? Guid.NewGuid().ToString() : item.Link,
                 Title = item.Title,
                 Author = item.Author,
                 Content = item.Content,
                 Link = item.Link,
-                Date = (DateTime)item.PublishingDate!
-            }
-        ).OrderBy(n => n.Date).ToList();
+                Date = date,
+            });
+        }
+        _newsList = newsList.OrderBy(n => n.Date).ToList();
     }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
@@ -1,12 +1,17 @@
-﻿using CommunityToolkit.Mvvm.Input;
+﻿using System.Threading.Tasks;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.Input;
 using Ksp2Redux.Tools.Launcher.Services;
 using Ksp2Redux.Tools.Launcher.ViewModels.Shared;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Community;
 
-public partial class CommunityTabViewModel(INewsService newsService) : ViewModelBase
+public partial class CommunityTabViewModel(INewsService newsService, IMessageBoxService messageBoxService, ILogService log) : ViewModelBase
 {
-    private int SelectedNewsId
+    public Task LaunchExternalLinkAsync(TopLevel? topLevel, string? url)
+        => ExternalLinkLauncher.LaunchAsync(topLevel, url, messageBoxService, log);
+
+    private string? SelectedNewsId
     {
         get;
         set
@@ -19,13 +24,15 @@ public partial class CommunityTabViewModel(INewsService newsService) : ViewModel
                 OnPropertyChanged(nameof(NewsVisible));
             }
         }
-    } = -1;
+    }
 
-    public NewsItemViewModel SelectedNews => new(newsService, newsService.GetNews(SelectedNewsId));
-    
-    public bool NewsVisible => SelectedNewsId != -1;
-    
-    public void SetSelectedNewsId(int newsId)
+    // Falls back to an empty News record if the selected post no longer exists (e.g. the feed was
+    // refetched and dropped it) instead of throwing or showing stale content.
+    public NewsItemViewModel SelectedNews => new(newsService.GetNews(SelectedNewsId) ?? new());
+
+    public bool NewsVisible => SelectedNewsId is not null;
+
+    public void SetSelectedNewsId(string? newsId)
     {
         SelectedNewsId = newsId;
     }
@@ -33,6 +40,6 @@ public partial class CommunityTabViewModel(INewsService newsService) : ViewModel
     [RelayCommand]
     private void DeselectNews()
     {
-        SelectedNewsId = -1;
+        SelectedNewsId = null;
     }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -153,6 +153,9 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
+    public Task LaunchExternalLinkAsync(TopLevel? topLevel, string url)
+        => ExternalLinkLauncher.LaunchAsync(topLevel, url, _messageBoxService, _log);
+
     // Startup initialization failing is more severe than a background task like the news feed
     // failing to load (which just leaves a list empty) - if this throws, feeds/install detection/
     // the update check may not have run at all, so tell the user instead of failing silently.
@@ -278,7 +281,7 @@ public partial class MainWindowViewModel : ViewModelBase
         List<News> newsList = await _newsService.FindAllNews();
         foreach (News news in newsList)
         {
-            _newsCollectionService.Add(new Shared.NewsItemViewModel(_newsService, news));
+            _newsCollectionService.Add(new Shared.NewsItemViewModel(news));
         }
 
         MaybeAutoSelectLatestCommunityNews();

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Shared/NewsItemViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Shared/NewsItemViewModel.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using Ksp2Redux.Tools.Launcher.Models;
-using Ksp2Redux.Tools.Launcher.Services;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Shared;
 
-public class NewsItemViewModel(INewsService newsService, News news) : ViewModelBase
+public class NewsItemViewModel(News news) : ViewModelBase
 {
     public News News { get; set; } = news;
-    public int NewsId => newsService.GetNewsId(News);
+    public string NewsId => News.Id;
 
     public string Title => News.Title;
 

--- a/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels.Community;
@@ -13,16 +12,8 @@ public partial class CommunityTabView : UserControl
 
     public CommunityTabView() => AvaloniaXamlLoader.Load(this);
 
-    private void LaunchUri(Uri uri)
+    private async void NewsLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        TopLevel.GetTopLevel(this)!.Launcher.LaunchUriAsync(uri);
-    }
-
-    private void NewsLink_OnClick(object? sender, RoutedEventArgs e)
-    {
-        if (ViewModel.SelectedNews.Link is null)
-            return;
-        
-        LaunchUri(new Uri(ViewModel.SelectedNews.Link));
+        await ViewModel.LaunchExternalLinkAsync(TopLevel.GetTopLevel(this), ViewModel.SelectedNews.Link);
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
@@ -26,7 +26,7 @@ public partial class NewsItemView : UserControl
         var communityTab = mainWindow.FindControl<TabItem>("CommunityTab");
         if (mainTabControl is null || communityTab is null) return;
 
-        mainWindowViewModel.CommunityTab.SetSelectedNewsId(ViewModel?.NewsId ?? -1);
+        mainWindowViewModel.CommunityTab.SetSelectedNewsId(ViewModel?.NewsId);
         mainTabControl.SelectedItem = communityTab;
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml.cs
@@ -11,6 +11,7 @@ namespace Ksp2Redux.Tools.Launcher.Views;
 public partial class SidebarView : UserControl
 {
     private HomeTabViewModel? Model => (DataContext as MainWindowViewModel)?.HomeTab;
+    private MainWindowViewModel? MainViewModel => DataContext as MainWindowViewModel;
     private Button? LaunchButtonControl => this.FindControl<Button>("LaunchButton");
     private Button? UpdateButtonControl => this.FindControl<Button>("UpdateButton");
     private Button? CancelButtonControl => this.FindControl<Button>("CancelButton");
@@ -71,43 +72,44 @@ public partial class SidebarView : UserControl
         }
     }
 
-    private void LaunchUri(Uri uri)
+    private async void LaunchUri(string url)
     {
-        TopLevel.GetTopLevel(this)!.Launcher.LaunchUriAsync(uri);
+        if (MainViewModel is not { } model) return;
+        await model.LaunchExternalLinkAsync(TopLevel.GetTopLevel(this), url);
     }
 
     private void WebsiteLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://ksp2redux.org"));
+        LaunchUri("https://ksp2redux.org");
     }
 
     private void DiscordLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://discord.gg/8yq8d5VGQR"));
+        LaunchUri("https://discord.gg/8yq8d5VGQR");
     }
 
     private void TikTokLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://tiktok.com/@ksp2redux"));
+        LaunchUri("https://tiktok.com/@ksp2redux");
     }
 
     private void RedditLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://reddit.com/r/KSP2Redux"));
+        LaunchUri("https://reddit.com/r/KSP2Redux");
     }
 
     private void ForumsLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://forum.kerbalspaceprogram.com/topic/226985-ksp2-redux"));
+        LaunchUri("https://forum.kerbalspaceprogram.com/topic/226985-ksp2-redux");
     }
 
     private void YoutubeLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://www.youtube.com/@RendezvousEntertainmentModding"));
+        LaunchUri("https://www.youtube.com/@RendezvousEntertainmentModding");
     }
 
     private void GithubLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://github.com/KSP2Redux"));
+        LaunchUri("https://github.com/KSP2Redux");
     }
 }


### PR DESCRIPTION
## Summary
Fifth batch of the v0.2.0 reliability/hardening pass (stacked on #40, "Harden Settings input" — this PR's diff is scoped to just this batch's changes; it will auto-retarget once #40 merges).

- **Social and news links could throw or fail without feedback**: Every social link (Sidebar) and the Community news-post link now go through a shared `ExternalLinkLauncher` that validates the URL is an absolute http(s) link, awaits the launch, and shows a "Couldn't Open Link" dialog on failure - instead of a malformed feed link or a missing default browser throwing straight out of a click handler.
- **The selected news article was tracked by list position, not identity**: `News` now carries a stable `Id` (its link) instead of being addressed by its position in the backing list. Previously, refetching the feed at a different length while a post was open could reopen a completely different article or throw an out-of-range exception. `CommunityTabViewModel` and `NewsItemViewModel` were updated to use this id end-to-end; a missing/stale id now falls back to an empty post instead of crashing.
- **One malformed RSS entry blanked the entire news list**: `NewsService` now skips (and logs) individual RSS items with a missing or unparseable publish date instead of letting one bad blog post throw and blank the entire news list.
