### PR TITLE
Everything else: detection diagnostics, network timeouts, and remaining low-severity fixes

### DIFF
--- a/Ksp2Redux.Tools.Common/Ksp2Patch.cs
+++ b/Ksp2Redux.Tools.Common/Ksp2Patch.cs
@@ -78,11 +78,19 @@ public class Ksp2Patch : IDisposable
         foreach (IFileInfo file in patchDir.GetFiles())
         {
             if (FileInformation.IgnoreFiles(_fileSystem).Contains(_fileSystem.Path.Combine(prefix, file.Name))) continue;
+
+            // Snapshot the source file's size/timestamp before reading it, so a change made to the
+            // source tree while this (potentially long-running) diff is in progress is caught as a
+            // loud failure here rather than silently producing a patch that fails its own hash check.
+            var sizeAtSnapshot = file.Length;
+            var lastWriteAtSnapshot = file.LastWriteTimeUtc;
+
             if (_fileSystem.File.Exists(_fileSystem.Path.Combine(originalDirectory, file.Name)))
             {
                 Console.WriteLine($"Checking {prefix}/{file.Name}");
                 byte[] oldBytes = _fileSystem.File.ReadAllBytes(_fileSystem.Path.Combine(originalDirectory, file.Name));
                 byte[] newBytes = _fileSystem.File.ReadAllBytes(file.FullName);
+                AssertFileUnchangedSinceSnapshot(file, sizeAtSnapshot, lastWriteAtSnapshot, prefix);
                 if (oldBytes.SequenceEqual(newBytes))
                 {
                     continue;
@@ -123,6 +131,7 @@ public class Ksp2Patch : IDisposable
                 input.Position = 0;
                 using var newSHA = SHA256.Create();
                 newSHA.ComputeHash(input);
+                AssertFileUnchangedSinceSnapshot(file, sizeAtSnapshot, lastWriteAtSnapshot, prefix);
                 _manifest.Operations.Add(new PatchOperation
                 {
                     Action = PatchOperation.PatchAction.Add,
@@ -169,6 +178,17 @@ public class Ksp2Patch : IDisposable
         }
 
         return sum;
+    }
+
+    private void AssertFileUnchangedSinceSnapshot(IFileInfo file, long sizeAtSnapshot, DateTime lastWriteAtSnapshot, string prefix)
+    {
+        var current = _fileSystem.FileInfo.New(file.FullName);
+        if (current.Length != sizeAtSnapshot || current.LastWriteTimeUtc != lastWriteAtSnapshot)
+        {
+            throw new InvalidOperationException(
+                $"{_fileSystem.Path.Combine(prefix, file.Name)} changed while the patch was being generated. " +
+                "The source directory must stay stable for the whole diff - re-run the generator once nothing else is writing to it.");
+        }
     }
 
     public static Ksp2Patch FromFile(IFileSystem fileSystem, IZipFileService zipFileService, string path)

--- a/Ksp2Redux.Tools.Launcher.Test/AppManifestTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/AppManifestTest.cs
@@ -1,0 +1,24 @@
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class AppManifestTest
+{
+    private static string FindAppManifestPath()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "Ksp2Redux.Tools.Launcher", "app.manifest");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException("Could not locate Ksp2Redux.Tools.Launcher/app.manifest by walking up from the test output directory.");
+    }
+
+    [Test]
+    public void AppManifest_DeclaresLongPathAware()
+    {
+        var content = File.ReadAllText(FindAppManifestPath());
+
+        Assert.That(content, Does.Contain("longPathAware"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/CacheServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/CacheServiceTest.cs
@@ -1,0 +1,48 @@
+using System.IO.Compression;
+using Ksp2Redux.Tools.Common.Service;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class CacheServiceTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+
+    private static (CacheService Service, MockFileSystem FileSystem, Mock<IZipFileService> ZipFileService) MakeService()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+        fs.Directory.CreateDirectory(fs.Path.GetTempPath());
+        var zipFileService = new Mock<IZipFileService>();
+        return (new CacheService(fs, zipFileService.Object), fs, zipFileService);
+    }
+
+    [Test]
+    public void RecursivelyCreateCache_ZipCreationFails_DeletesThePartialTempFile()
+    {
+        var (service, fs, zipFileService) = MakeService();
+        zipFileService.Setup(z => z.NewArchive(It.IsAny<Stream>(), It.IsAny<ZipArchiveMode>(), It.IsAny<bool>()))
+            .Throws(new IOException("disk full"));
+
+        Assert.Throws<IOException>(() => service.RecursivelyCreateCache(InstallDir));
+
+        var leftoverTempFiles = fs.Directory.EnumerateFiles(fs.Path.GetTempPath(), "uninstall-*.zip");
+        Assert.That(leftoverTempFiles, Is.Empty, "A failed snapshot must not leave a partial temp file behind.");
+    }
+
+    [Test]
+    public void RecursivelyRestoreCache_UninstallZipMissing_ThrowsCacheRestoreExceptionWithContext()
+    {
+        var (service, _, _) = MakeService();
+
+        var ex = Assert.Throws<CacheRestoreException>(() => service.RecursivelyRestoreCache(InstallDir));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Directory, Is.EqualTo(InstallDir));
+            Assert.That(ex.ExpectedFile, Is.EqualTo("uninstall.zip"));
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/LaunchGameRevalidationTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/LaunchGameRevalidationTest.cs
@@ -1,0 +1,56 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class LaunchGameRevalidationTest
+{
+    [AvaloniaTest]
+    public async Task LaunchGame_InstallExeRemovedSinceLastRefresh_ShowsCouldntLaunchInsteadOfCrashing()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        const string exePath = @"C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program 2\KSP2_x64.exe";
+        TestAppBuilder.FileSystem.File.Delete(exePath);
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await homeTabViewModel.LaunchGameCommand.ExecuteAsync(null);
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null);
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Launch", It.Is<string>(s => s.Contains("not detected")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2DetectorServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2DetectorServiceTest.cs
@@ -1,0 +1,61 @@
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class Ksp2DetectorServiceTest
+{
+    private const string SteamRoot = @"C:\Program Files (x86)\Steam";
+
+    private static (Ksp2DetectorService Service, MockFileSystem FileSystem, Mock<ILogService> Log) MakeService()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        var env = new MockEnvironmentProvider();
+        var os = new Mock<IOperatingSystemService>();
+        os.Setup(o => o.IsLinux()).Returns(false);
+        var log = new Mock<ILogService>();
+        fs.Directory.CreateDirectory(SteamRoot);
+        return (new Ksp2DetectorService(fs, env, os.Object, log.Object), fs, log);
+    }
+
+    [Test]
+    public void DetectKsp2InstallLocation_LibraryFoldersVdfExistsButParsesToNothing_LogsAWarning()
+    {
+        var (service, fs, log) = MakeService();
+        // A file caught mid-write by Steam - present, but the regex finds no "path" entries in it.
+        fs.Directory.CreateDirectory(fs.Path.Combine(SteamRoot, "steamapps"));
+        fs.File.WriteAllText(fs.Path.Combine(SteamRoot, "steamapps", "libraryfolders.vdf"), "not valid vdf content");
+
+        service.DetectKsp2InstallLocation();
+
+        log.Verify(l => l.Warn(
+            It.Is<string>(s => s.Contains("libraryfolders.vdf") && s.Contains("no library paths")),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public void DetectKsp2InstallLocation_AppManifestExistsButInstallDirUnparseable_LogsAWarning()
+    {
+        var (service, fs, log) = MakeService();
+        fs.Directory.CreateDirectory(fs.Path.Combine(SteamRoot, "steamapps"));
+        fs.File.WriteAllText(fs.Path.Combine(SteamRoot, "steamapps", "appmanifest_954850.acf"), "not valid acf content");
+
+        service.DetectKsp2InstallLocation();
+
+        log.Verify(l => l.Warn(
+            It.Is<string>(s => s.Contains("appmanifest_954850.acf") && s.Contains("installdir")),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public void DetectKsp2InstallLocation_NoLibraryFoldersVdfAtAll_DoesNotLogAWarning()
+    {
+        // Not having extra libraries configured is the normal case and shouldn't look like a parse failure.
+        var (service, fs, log) = MakeService();
+
+        service.DetectKsp2InstallLocation();
+
+        log.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/CacheRestoreException.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/CacheRestoreException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+/// <summary>
+/// Thrown by <see cref="CacheService.RecursivelyRestoreCache"/> when the pre-patch snapshot it needs
+/// to restore from is missing, carrying the directory and expected file so the failure is
+/// distinguishable from other exceptions in a log without inspecting the message text.
+/// </summary>
+public sealed class CacheRestoreException(string directory, string expectedFile)
+    : Exception($"Original stock files were deleted - expected \"{expectedFile}\" under \"{directory}\", uninstallation is impossible.")
+{
+    public string Directory { get; } = directory;
+    public string ExpectedFile { get; } = expectedFile;
+}

--- a/Ksp2Redux.Tools.Launcher/Services/CacheService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/CacheService.cs
@@ -40,15 +40,25 @@ public class CacheService(IFileSystem fileSystem, IZipFileService zipFileService
         }
 
         var tempFile = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), $"uninstall-{Guid.CreateVersion7()}.zip");
-        using (var saveStream = fileSystem.File.Open(tempFile, FileMode.Create, FileAccess.Write))
+        try
         {
-            using (var zipArchive = zipFileService.NewArchive(saveStream, ZipArchiveMode.Create, false))
+            using (var saveStream = fileSystem.File.Open(tempFile, FileMode.Create, FileAccess.Write))
             {
-                AddFolder(zipArchive, directory, "");
-            }   
+                using (var zipArchive = zipFileService.NewArchive(saveStream, ZipArchiveMode.Create, false))
+                {
+                    AddFolder(zipArchive, directory, "");
+                }
+            }
+
+            fileSystem.File.Move(tempFile, fileSystem.Path.Combine(directory, "uninstall.zip"));
         }
-        
-        fileSystem.File.Move(tempFile, fileSystem.Path.Combine(directory, "uninstall.zip"));
+        catch
+        {
+            // A partial snapshot (locked file, full disk) would otherwise sit in the temp folder
+            // forever, silently eating disk space across repeated failed attempts.
+            try { if (fileSystem.File.Exists(tempFile)) fileSystem.File.Delete(tempFile); } catch { }
+            throw;
+        }
     }
 
     public void AddFolder(IZipArchive archive, string directory, string prefix)
@@ -75,7 +85,7 @@ public class CacheService(IFileSystem fileSystem, IZipFileService zipFileService
     {
         if (!fileSystem.File.Exists(fileSystem.Path.Combine(directory, "uninstall.zip")))
         {
-            throw new Exception("Original stock files were deleted, uninstallation is impossible");
+            throw new CacheRestoreException(directory, "uninstall.zip");
         }
 
         if (isForRepatch)

--- a/Ksp2Redux.Tools.Launcher/Services/Ksp2DetectorService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/Ksp2DetectorService.cs
@@ -10,7 +10,7 @@ public interface IKsp2DetectorService
     public string? DetectKsp2InstallLocation();
 }
 
-public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, IOperatingSystemService operatingSystemService)
+public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, IOperatingSystemService operatingSystemService, ILogService log)
     : IKsp2DetectorService
 {
     private const string Ksp2SteamAppId = "954850";
@@ -120,18 +120,29 @@ public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider en
         {
             content = fileSystem.File.ReadAllText(libraryFoldersVdf);
         }
-        catch
+        catch (Exception ex)
         {
+            log.Warn($"Found {libraryFoldersVdf} but couldn't read it: {ex.Message}. Additional Steam libraries won't be checked.");
             yield break;
         }
 
+        var matchCount = 0;
         foreach (Match match in LibraryPathRegex.Matches(content))
         {
             var path = match.Groups["path"].Value.Replace(@"\\", @"\");
             if (!string.IsNullOrWhiteSpace(path))
             {
+                matchCount++;
                 yield return path;
             }
+        }
+
+        // A zero-match result here is indistinguishable from "just no extra libraries configured" to
+        // the user - but it can also mean Steam had this file mid-write when we read it, which would
+        // otherwise look identical to "KSP2 isn't installed" once detection comes up empty.
+        if (matchCount == 0)
+        {
+            log.Warn($"{libraryFoldersVdf} exists but no library paths were parsed out of it. If KSP2 isn't detected, this file may have been read mid-write.");
         }
     }
 
@@ -142,13 +153,19 @@ public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider en
         {
             content = fileSystem.File.ReadAllText(manifestPath);
         }
-        catch
+        catch (Exception ex)
         {
+            log.Warn($"Found {manifestPath} but couldn't read it: {ex.Message}.");
             return null;
         }
 
         var match = InstallDirRegex.Match(content);
-        return match.Success ? match.Groups["installdir"].Value : null;
+        if (!match.Success)
+        {
+            log.Warn($"{manifestPath} exists but its installdir couldn't be parsed out of it. If KSP2 isn't detected, this file may have been read mid-write.");
+            return null;
+        }
+        return match.Groups["installdir"].Value;
     }
 
     private static readonly Regex LibraryPathRegex = new(

--- a/Ksp2Redux.Tools.Launcher/Services/ManifestReleasesFeedProviderService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/ManifestReleasesFeedProviderService.cs
@@ -20,7 +20,9 @@ public interface IManifestReleasesFeedProviderService
 public class ManifestReleasesFeedProviderService(IAssemblyService assemblyService, ILogService log) : IManifestReleasesFeedProviderService
 {
     private readonly Dictionary<FeedInfo, GitHubClient> _clients = new();
-    private readonly HttpClient _downloadClient = new();
+    // ResponseHeadersRead means this only bounds getting the response headers for a patch download,
+    // not the body copy that follows - safe to keep short even for large patch files.
+    private readonly HttpClient _downloadClient = new() { Timeout = TimeSpan.FromSeconds(30) };
 
     private GitHubClient GetOrCreateClient(FeedInfo feed)
     {

--- a/Ksp2Redux.Tools.Launcher/Services/NewsProviderService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/NewsProviderService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using CodeHollow.FeedReader;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
@@ -15,10 +17,20 @@ public class NewsProviderService : INewsProviderService
     // private string _tomlTargetUrl => _rawRepoTargetUrl + _tomlTargetFile;
     // private string _imageTargetUrl => _rawRepoTargetUrl + "images/";
 
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(15);
     private const string RssFeed = "https://ksp2redux.org/blog/rss.xml";
+
     public async Task<Feed> GetSyndicationFeed()
     {
-        var items = await FeedReader.ReadAsync(RssFeed);
-        return items ?? new Feed();
+        using var cts = new CancellationTokenSource(RequestTimeout);
+        try
+        {
+            var items = await FeedReader.ReadAsync(RssFeed, cts.Token);
+            return items ?? new Feed();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Timed out after {RequestTimeout.TotalSeconds:0}s fetching the news feed from {RssFeed}.");
+        }
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -60,7 +60,7 @@ public class UpdateService : IUpdateService
 
     public UpdateService(ILauncherConfigService launcherConfigService, IFileSystem fileSystem, IEnvironmentProvider environmentProvider, IAssemblyService assemblyService, IMessageBoxService messageBoxService, ILogService log)
     {
-        _http = new HttpClient();
+        _http = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
         _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(
             new ProductHeaderValue("Ksp2Redux.Tools.Launcher", assemblyService.GetName().Version?.ToString() ?? "0.0.0")));
         _fileSystem = fileSystem;
@@ -210,7 +210,12 @@ public class UpdateService : IUpdateService
 
                     if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        await Process.Start("chmod", $"+x \"{updatePath}\"").WaitForExitAsync();
+                        using var chmod = Process.Start("chmod", $"+x \"{updatePath}\"")!;
+                        await chmod.WaitForExitAsync();
+                        if (chmod.ExitCode != 0)
+                        {
+                            throw new InvalidOperationException($"chmod +x on {updatePath} exited with code {chmod.ExitCode}.");
+                        }
                     }
 
                     TriggerRestart(updatePath);

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -217,7 +217,17 @@ public partial class HomeTabViewModel : ViewModelBase
     [RelayCommand]
     public async Task LaunchGame()
     {
-        if (_ksp2InstallService.Ksp2 is null) return;
+        // Re-validate right before using it rather than trusting whatever was cached at the last
+        // refresh - the install could have been moved, had its drive ejected, or been deleted in
+        // the meantime if the app was left idle.
+        _ksp2InstallService.TryLoadKsp2Install();
+        if (_ksp2InstallService.Ksp2 is not { IsValid: true })
+        {
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Launch",
+                "KSP2 installation not detected. Please select a directory containing KSP2 on the settings tab.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
         var activeEntry = _ksp2InstallService.ActiveEntry;
         if (activeEntry is null) return;
 

--- a/Ksp2Redux.Tools.Launcher/app.manifest
+++ b/Ksp2Redux.Tools.Launcher/app.manifest
@@ -16,11 +16,19 @@
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of the Windows versions that this application has been tested on
-           and is designed to work with. Uncomment the appropriate elements, 
+           and is designed to work with. Uncomment the appropriate elements,
            and Windows will automatically select the most compatible environment. -->
 
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+
+  <!-- A deeply nested Steam library combined with a long username/mod path could otherwise
+       approach the legacy 260-character MAX_PATH limit during patch extraction. -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/Ksp2Redux.Tools.Uploader/Program.cs
+++ b/Ksp2Redux.Tools.Uploader/Program.cs
@@ -103,13 +103,21 @@ if (!isDeleteOnly)
 
         var asset = await github.Repository.Release.UploadAsset(createdRelease, upload);
 
+        var localSize = new FileInfo(patch.File).Length;
+        if (asset.Size != localSize)
+        {
+            throw new InvalidOperationException(
+                $"Uploaded asset '{fileName}' reports size {asset.Size} bytes on GitHub, but the local file is {localSize} bytes. " +
+                "The upload may have been truncated or corrupted - not publishing this release.");
+        }
+
         var releasePatch = new ReleasePatch
         {
             Version = uploadManifest.Version,
             Label = uploadManifest.Label,
             ReleasedAt = DateTime.UtcNow,
             ChecksumSha256 = GetChecksum(patch.File),
-            Size = new FileInfo(patch.File).Length,
+            Size = localSize,
             Requires = new PatchRequirement
             {
                 Version = patch.PreviousVersion,


### PR DESCRIPTION
## Summary
Sixth and final batch of the v0.2.0 reliability/hardening pass (stacked on #41, "Community and news polish" — this PR's diff is scoped to just this batch's changes; it will auto-retarget once #41 merges).

- **Steam/Epic detection failed silently on malformed library files**: `Ksp2DetectorService` now logs a warning when a Steam `libraryfolders.vdf` or `appmanifest_*.acf` file is found but nothing parseable comes out of it (e.g. read mid-write by Steam), so that failure mode no longer looks identical to "KSP2 just isn't installed."
- **The Linux self-update's chmod didn't check its own exit code**: The `chmod +x` step now checks its exit code and throws (caught by the existing update-failure handling) instead of assuming success.
- **A failed cache snapshot could leave multi-gigabyte orphaned files**: `CacheService.RecursivelyCreateCache` now deletes its partial temp file if zipping the snapshot fails, instead of leaking it into the temp folder on every failed attempt.
- **No timeout on manifest, patch, or news requests**: Added explicit timeouts to `UpdateService`'s and `ManifestReleasesFeedProviderService`'s `HttpClient`s (60s / 30s) and to the news feed fetch (15s via `CancellationTokenSource`), instead of relying on the default 100s with no indication anything is stuck.
- **Launch didn't re-check the install right before using it**: `HomeTabViewModel.LaunchGame` now re-validates the active install (`TryLoadKsp2Install` + `IsValid`) immediately before launching, instead of trusting whatever was cached at the last refresh - catching a moved/ejected/deleted install with a clear message instead of a confusing failure.
- **A cache-restore failure threw a bare, contextless exception**: The failure when `uninstall.zip` is missing now throws a dedicated `CacheRestoreException` carrying the directory and expected filename, instead of a bare `Exception` with a plain string.
- **Long-path support in the app manifest was unconfirmed**: Added `longPathAware` to `app.manifest` for deeply nested Steam library / mod paths.
- **The uploader didn't re-verify an asset after publishing it**: The Uploader now verifies the uploaded asset's reported size matches the local file before publishing the release.
- **The patch generator read files non-atomically while diffing**: The patch generator's `RecursiveDiff` now asserts a source file's size/timestamp haven't changed between reading it and finishing its manifest entry, catching a source tree that's being edited mid-generation instead of silently shipping a patch that would fail its own hash check.

**No action needed**: "Some event subscriptions are never removed" was already flagged in the audit as harmless with no live risk. "The Mods tab is a live, empty placeholder" already has "coming soon" messaging. "A failed self-update relaunch never tells the user" was already implemented on the shared `reliability/patch-pipeline-hardening` branch this whole stack builds on.
