### PR TITLE
Disable Install/Update/Launch when the game version can't be detected

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UnknownGameVersionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UnknownGameVersionTest.cs
@@ -1,0 +1,54 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class UnknownGameVersionTest
+{
+    [AvaloniaTest]
+    public void UpdateMainButtonState_GameVersionCouldNotBeDetected_DisablesTheMainButton()
+    {
+        // Arrange - IsValid only confirms the exe exists; it says nothing about whether we could
+        // read its version. A stock install whose VersionID type is missing an expected field (a
+        // game update that changed field names, an unsupported distribution, etc.) used to leave
+        // Install/Update enabled with an unknown "from" version - see issue #26.
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        // Override the module set up by MockKsp2StockSteamInstall with one whose VersionID type is
+        // missing VERSION_TEXT, so FromVersionIDType throws and detection fails.
+        var brokenModule = TestHelpers.GenerateMockVersionID(("DEBUG_INFO", "BUILD_INFO"));
+        TestAppBuilder.ModuleDefinitionService
+            .Setup(m => m.ReadModule(
+                @"C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program 2\KSP2_x64_Data\Managed\Assembly-CSharp.dll"))
+            .Returns(brokenModule.module);
+
+        // Act
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTabViewModel.MainButtonEnabled, Is.False,
+                "Install/Update/Launch must not be reachable when the current game version is unknown.");
+            Assert.That(homeTabViewModel.MainButtonTooltip, Does.Contain("Couldn't detect the installed game version"));
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionSelectionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionSelectionTest.cs
@@ -1,0 +1,95 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Controls;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class VersionSelectionTest
+{
+    private const string DefaultChannel = "beta";
+    private const string OtherChannel = "stable";
+
+    [AvaloniaTest]
+    public void ChangingAnInstallSetting_DoesNotResetTheSelectedVersion()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        ReleasePatch patch = new()
+        {
+            ChecksumSha256 = "0",
+            ReleasedAt = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            Requires = new PatchRequirement { Version = null },
+            Size = 10,
+            Url = "https://github.com/patch1Rollup.patch",
+            Version = "0.2.3.1.1234",
+        };
+
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel))))
+            .ReturnsAsync(new ReleaseManifest
+            {
+                Channel = DefaultChannel,
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [patch],
+                SchemaVersion = 1
+            });
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel) == false)))
+            .ReturnsAsync((FeedInfo f) => new ReleaseManifest
+            {
+                Channel = f.Filename.Split('-', '.')[1],
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [],
+                SchemaVersion = 1
+            });
+
+        // Act
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        GroupedComboBox? versionSelectorCombobox = window
+            .GetVisualDescendants()
+            .OfType<GroupedComboBox>()
+            .FirstOrDefault(x => x.Name == "VersionSelector");
+        Assert.That(versionSelectorCombobox, Is.Not.Null);
+
+        var nonDefaultVersion = versionSelectorCombobox.GroupedItems
+            .OfType<GameVersionViewModel>()
+            .Single(g => g.VersionString.Contains("0.2.3.1.1234"));
+        versionSelectorCombobox.SelectedItem = nonDefaultVersion;
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+        Assert.That(homeTabViewModel.SelectedVersion?.VersionString, Does.Contain("0.2.3.1.1234"));
+
+        // Simulate a settings-page change to the active install (e.g. toggling "disable graphics jobs"),
+        // which fires ActiveInstallChanged - this used to silently reset the version dropdown.
+        var ksp2InstallService = TestAppBuilder.ServiceProvider.GetRequiredService<IKsp2InstallService>();
+        var activeEntryId = ksp2InstallService.ActiveEntry!.Id;
+        ksp2InstallService.UpdateInstallDisableGraphicsJobs(activeEntryId, true);
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert
+        Assert.That(homeTabViewModel.SelectedVersion?.VersionString, Does.Contain("0.2.3.1.1234"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -42,6 +42,7 @@ public class UpdateService : IUpdateService
     private ILogService _log;
 
     private static bool _isSingleFile;
+    private bool _checkInProgress;
 
     private class GitHubReleaseAsset
     {
@@ -84,6 +85,27 @@ public class UpdateService : IUpdateService
     /// </summary>
     /// <returns>A boolean whether to allow updating redux versions after this</returns>
     public async Task<bool> CheckAndPerformUpdateAsync()
+    {
+        // Called on a 10-minute timer as well as at startup and from a manual button. If a check
+        // (and its "Update Found" dialog) is still awaiting a response, skip instead of stacking
+        // another dialog on top - left running overnight this used to pile up dozens of them.
+        if (_checkInProgress)
+        {
+            _log.Info("An update check is already in progress, skipping this one.");
+            return true;
+        }
+        _checkInProgress = true;
+        try
+        {
+            return await CheckAndPerformUpdateCoreAsync();
+        }
+        finally
+        {
+            _checkInProgress = false;
+        }
+    }
+
+    private async Task<bool> CheckAndPerformUpdateCoreAsync()
     {
         var releasesUrl = $"https://api.github.com/repos/{_owner}/{_repo}/releases";
         _log.Info($"Checking for launcher updates from {releasesUrl} (current version {_version}).");

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -125,7 +125,7 @@ public partial class HomeTabViewModel : ViewModelBase
     {
         if(updateChannels)
             await UpdateAsync();
-        RebuildVersionsCollection();
+        RebuildVersionsCollectionPreservingSelection();
         UpdateMainButtonState();
     }
     private async Task UpdateAsync()
@@ -146,10 +146,18 @@ public partial class HomeTabViewModel : ViewModelBase
         // otherwise a background refresh would clobber the Cancel button mid operation.
         if (_cancelCurrentOperation is not null) return;
 
-        // RebuildVersionsCollection resets SelectedVersion to a default, which would pull the
-        // user's choice out from under them on every periodic refresh. Capture and restore it.
-        var previous = SelectedVersion;
         await UpdateAsync();
+        RebuildVersionsCollectionPreservingSelection();
+        UpdateMainButtonState();
+    }
+
+    // RebuildVersionsCollection resets SelectedVersion to a default, which would pull the user's
+    // choice out from under them any time the list gets rebuilt - a periodic feed refresh, or an
+    // unrelated settings change to the active install (which also fires ActiveInstallChanged).
+    // Capture and restore it around the rebuild instead.
+    private void RebuildVersionsCollectionPreservingSelection()
+    {
+        var previous = SelectedVersion;
         RebuildVersionsCollection();
         if (previous is not null)
         {
@@ -157,7 +165,6 @@ public partial class HomeTabViewModel : ViewModelBase
                 v.Channel == previous.Channel && v.Version.Equals(previous.Version));
             if (match is not null) SelectedVersion = match;
         }
-        UpdateMainButtonState();
     }
 
     [RelayCommand]

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -250,6 +250,17 @@ public partial class HomeTabViewModel : ViewModelBase
             return;
         }
 
+        // IsValid only confirms the exe exists - it says nothing about whether we could actually
+        // read its version. Falling through without this check let Install/Update stay enabled with
+        // an unknown "from" version, which crashed or hung once clicked (see issue #26).
+        if (ksp2.GameVersion is null)
+        {
+            MainButtonEnabled = false;
+            MainButtonShown = MainButtonState.Launch;
+            MainButtonTooltip = "Couldn't detect the installed game version. Verifying game files through Steam/Epic, or reinstalling the game, may fix this.";
+            return;
+        }
+
         var selectedVersion = SelectedVersion;
         if (selectedVersion is null)
         {
@@ -371,7 +382,17 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             return;
         }
-        
+
+        // The main button should already be disabled whenever this is null (see
+        // UpdateMainButtonState), but guard here too rather than pass a null "from" version into
+        // GetPatchListToVersion, which assumes a real GameVersion and would throw or search a
+        // patch graph that was never meant to be reached from "unknown".
+        if (ksp2.GameVersion is null)
+        {
+            Log("Couldn't detect the installed game version, so it's unclear which patches to apply. Verifying game files, or reinstalling the game, may fix this.");
+            return;
+        }
+
         // Set up process cancellation trigger.
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
@@ -379,9 +400,9 @@ public partial class HomeTabViewModel : ViewModelBase
         _cancelCurrentOperation = new CancellationTokenSource();
 
         Log("Creating install plan");
-            
+
         var plan = _releasesFeedService.ReleasesFeed[SelectedVersion.Channel]
-            .GetPatchListToVersion(_ksp2InstallService.Ksp2!.GameVersion!, SelectedVersion.Version);
+            .GetPatchListToVersion(ksp2.GameVersion, SelectedVersion.Version);
         try
         {
             await RunPlanOnInstall(plan, ksp2);

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
@@ -180,8 +180,7 @@
         <Panel Grid.Row="3" DataContext="{Binding HomeTab}">
           <Panel x:DataType="home:HomeTabViewModel">
             <Button Classes="main-button" IsVisible="True" Name="InstallButton" Command="{Binding InstallRedux}"
-                    IsEnabled="{Binding MainButtonEnabled}"
-                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
+                    IsEnabled="{Binding MainButtonEnabled}">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-install.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />


### PR DESCRIPTION
## Summary
Fixes #26.

The reported crash (`Sequence contains no matching element` inside `GameVersion.FromVersionIDType`) is already caught by `Ksp2Install.TryDetectGameVersionFromMainAssembly`'s try/catch and turned into a `VersionDetectionException` shown in a dialog - so that part isn't a true unhandled crash. But nothing downstream accounted for the resulting state: `Ksp2Install.IsValid` only confirms the exe exists, it says nothing about whether the version was actually readable, so `UpdateMainButtonState` fell through with `GameVersion == null` and left Install/Update/Launch enabled anyway.

Clicking it then called `GetPatchListToVersion` with the null `GameVersion` forced through with `!` (null-forgiving), which the method has no defined behavior for - this is what's actually behind "tool allows me to update the game but the update freezes immediately after start."

- `UpdateMainButtonState` now disables the button and shows "Couldn't detect the installed game version..." whenever `GameVersion` is null, instead of only checking `IsValid`.
- `RunPatchProcess` has the same check as a second line of defense, logging a clear message instead of passing a null version into `GetPatchListToVersion`.