### PR TITLE
v0.2.0: The Bulletproofing Update

### DIFF
--- a/Ksp2Redux.Tools.Common/Ksp2Patch.cs
+++ b/Ksp2Redux.Tools.Common/Ksp2Patch.cs
@@ -78,11 +78,19 @@ public class Ksp2Patch : IDisposable
         foreach (IFileInfo file in patchDir.GetFiles())
         {
             if (FileInformation.IgnoreFiles(_fileSystem).Contains(_fileSystem.Path.Combine(prefix, file.Name))) continue;
+
+            // Snapshot the source file's size/timestamp before reading it, so a change made to the
+            // source tree while this (potentially long-running) diff is in progress is caught as a
+            // loud failure here rather than silently producing a patch that fails its own hash check.
+            var sizeAtSnapshot = file.Length;
+            var lastWriteAtSnapshot = file.LastWriteTimeUtc;
+
             if (_fileSystem.File.Exists(_fileSystem.Path.Combine(originalDirectory, file.Name)))
             {
                 Console.WriteLine($"Checking {prefix}/{file.Name}");
                 byte[] oldBytes = _fileSystem.File.ReadAllBytes(_fileSystem.Path.Combine(originalDirectory, file.Name));
                 byte[] newBytes = _fileSystem.File.ReadAllBytes(file.FullName);
+                AssertFileUnchangedSinceSnapshot(file, sizeAtSnapshot, lastWriteAtSnapshot, prefix);
                 if (oldBytes.SequenceEqual(newBytes))
                 {
                     continue;
@@ -123,6 +131,7 @@ public class Ksp2Patch : IDisposable
                 input.Position = 0;
                 using var newSHA = SHA256.Create();
                 newSHA.ComputeHash(input);
+                AssertFileUnchangedSinceSnapshot(file, sizeAtSnapshot, lastWriteAtSnapshot, prefix);
                 _manifest.Operations.Add(new PatchOperation
                 {
                     Action = PatchOperation.PatchAction.Add,
@@ -169,6 +178,17 @@ public class Ksp2Patch : IDisposable
         }
 
         return sum;
+    }
+
+    private void AssertFileUnchangedSinceSnapshot(IFileInfo file, long sizeAtSnapshot, DateTime lastWriteAtSnapshot, string prefix)
+    {
+        var current = _fileSystem.FileInfo.New(file.FullName);
+        if (current.Length != sizeAtSnapshot || current.LastWriteTimeUtc != lastWriteAtSnapshot)
+        {
+            throw new InvalidOperationException(
+                $"{_fileSystem.Path.Combine(prefix, file.Name)} changed while the patch was being generated. " +
+                "The source directory must stay stable for the whole diff - re-run the generator once nothing else is writing to it.");
+        }
     }
 
     public static Ksp2Patch FromFile(IFileSystem fileSystem, IZipFileService zipFileService, string path)

--- a/Ksp2Redux.Tools.Common/Ksp2Patch.cs
+++ b/Ksp2Redux.Tools.Common/Ksp2Patch.cs
@@ -311,7 +311,7 @@ public class Ksp2Patch : IDisposable
                         IZipArchiveEntry? entry = _archive.GetEntry(operation.FileName + ".bsdiff");
                         if (entry != null)
                         {
-                            string outPath = _fileSystem.Path.Combine(tempPatchDir, entryFsName + ".bsdiff");
+                            string outPath = ResolveContainedPath(tempPatchDir, entryFsName + ".bsdiff");
                             _fileSystem.Directory.CreateDirectory(_fileSystem.Path.GetDirectoryName(outPath)!);
                             entry.ExtractToFile(_fileSystem, outPath);
                         }
@@ -323,7 +323,7 @@ public class Ksp2Patch : IDisposable
                         IZipArchiveEntry? entry = _archive.GetEntry(operation.FileName);
                         if (entry != null)
                         {
-                            string outPath = _fileSystem.Path.Combine(tempPatchDir, entryFsName);
+                            string outPath = ResolveContainedPath(tempPatchDir, entryFsName);
                             _fileSystem.Directory.CreateDirectory(_fileSystem.Path.GetDirectoryName(outPath)!);
                             entry.ExtractToFile(_fileSystem, outPath);
                         }
@@ -348,9 +348,25 @@ public class Ksp2Patch : IDisposable
                     try
                     {
                         string trueName = NormalizeEntryPath(operation.FileName);
-                        string targetPath = _fileSystem.Path.Combine(targetDirectory, trueName);
-                        string sourcePath = _fileSystem.Path.Combine(sourceDirectory, trueName);
+                        string targetPath = ResolveContainedPath(targetDirectory, trueName);
+                        string sourcePath = ResolveContainedPath(sourceDirectory, trueName);
                         string tempPath = targetPath + ".temp";
+
+                        // Each file write below is already atomic (verify-then-swap), so if a previous
+                        // attempt at this same plan got partway through before failing elsewhere, this
+                        // file may already be sitting in its correct final state. Retrying the whole
+                        // plan shouldn't mean redownloading/reapplying files that are already done.
+                        if (operation.Action is PatchOperation.PatchAction.Patch or PatchOperation.PatchAction.Add &&
+                            operation.FinalHash is not null && _fileSystem.File.Exists(targetPath))
+                        {
+                            await using FileSystemStream existingFile = _fileSystem.File.OpenRead(targetPath);
+                            if (await ValidateFileHashAsync(existingFile, operation.FinalHash))
+                            {
+                                log?.Invoke($"{trueName} already matches the expected result, skipping.");
+                                return;
+                            }
+                        }
+
                         if (operation.Action == PatchOperation.PatchAction.Patch)
                         {
                             log?.Invoke($"Applying binary patch to {trueName}");
@@ -364,51 +380,68 @@ public class Ksp2Patch : IDisposable
                                 );
                             }
                             log?.Invoke($"Creating temporary file for {trueName}");
-                            await CopyFileAsync(_fileSystem, sourcePath, tempPath);
+                            await RetryOnFileLockAsync(
+                                () => CopyFileAsync(_fileSystem, sourcePath, tempPath), trueName, log);
 
-                            await using (FileSystemStream originalFile = _fileSystem.File.OpenRead(tempPath))
+                            // Write the patched result to a co-located swap file and verify it fully
+                            // before ever touching the real target file, instead of truncating the
+                            // target up front - a crash or disk-full mid-write must never leave the
+                            // live game file half-written.
+                            string swapPath = targetPath + ".newtemp";
+                            try
                             {
-                                await using FileSystemStream targetFile = _fileSystem.File.Open(
-                                    targetPath,
-                                    FileMode.Create,
-                                    FileAccess.ReadWrite
-                                );
-
-                                if (!await ValidateFileHashAsync(originalFile, operation.OriginalHash!))
+                                await using (FileSystemStream originalFile = _fileSystem.File.OpenRead(tempPath))
                                 {
-                                    throw new InvalidDataException(
-                                        $"File {originalFile.Name} does not match expected hash " +
-                                        $"{FormatHash(operation.OriginalHash!)}. Cannot apply patch! Check that the " +
-                                        $"Redux patch you are applying is for the version of the game (Steam, portable " +
-                                        $"zip, or Epic) you are patching."
-                                    );
-                                }
-
-
-                                try
-                                {
-                                    string patchPath = _fileSystem.Path.Combine(tempPatchDir, trueName + ".bsdiff");
-                                    BinaryPatch.Apply(originalFile, () =>
+                                    if (!await ValidateFileHashAsync(originalFile, operation.OriginalHash!))
                                     {
-                                        var memory = new MemoryStream(_fileSystem.File.ReadAllBytes(patchPath));
-                                        return memory;
-                                    }, targetFile);
-                                }
-                                catch (Exception e)
-                                {
-                                    error?.Invoke(e.Message);
-                                    throw;
+                                        throw new InvalidDataException(
+                                            $"File {originalFile.Name} does not match expected hash " +
+                                            $"{FormatHash(operation.OriginalHash!)}. Cannot apply patch! Check that the " +
+                                            $"Redux patch you are applying is for the version of the game (Steam, portable " +
+                                            $"zip, or Epic) you are patching."
+                                        );
+                                    }
+
+                                    await using (FileSystemStream swapFile = _fileSystem.File.Open(
+                                                     swapPath, FileMode.Create, FileAccess.ReadWrite))
+                                    {
+                                        try
+                                        {
+                                            string patchPath = _fileSystem.Path.Combine(tempPatchDir, trueName + ".bsdiff");
+                                            BinaryPatch.Apply(originalFile, () =>
+                                            {
+                                                var memory = new MemoryStream(_fileSystem.File.ReadAllBytes(patchPath));
+                                                return memory;
+                                            }, swapFile);
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            error?.Invoke(e.Message);
+                                            throw;
+                                        }
+
+                                        if (!await ValidateFileHashAsync(swapFile, operation.FinalHash!))
+                                        {
+                                            throw new InvalidDataException(
+                                                $"Patched result for {trueName} does not match expected hash " +
+                                                $"{FormatHash(operation.FinalHash!)}."
+                                            );
+                                        }
+                                    }
                                 }
 
-                                if (!await ValidateFileHashAsync(targetFile, operation.FinalHash!))
-                                {
-                                    throw new InvalidDataException(
-                                        $"File {targetFile.Name} does not match expected hash " +
-                                        $"{FormatHash(operation.FinalHash!)}."
-                                    );
-                                }
+                                // Only now, with a fully verified replacement sitting beside it, do we
+                                // touch the real file - a single atomic rename instead of an in-place write.
+                                await RetryOnFileLockAsync(
+                                    () => { _fileSystem.File.Move(swapPath, targetPath, true); return Task.CompletedTask; },
+                                    trueName, log);
                             }
-                            
+                            finally
+                            {
+                                try { if (_fileSystem.File.Exists(swapPath)) _fileSystem.File.Delete(swapPath); }
+                                catch { /* best-effort cleanup */ }
+                            }
+
                             // Delete the original file if we are not caching it
                             _fileSystem.File.Delete(tempPath);
                         }
@@ -427,27 +460,42 @@ public class Ksp2Patch : IDisposable
                         }
                         else // Add
                         {
-
                             log?.Invoke($"Copying {trueName} from patch");
 
                             IDirectoryInfo? parent = _fileSystem.FileInfo.New(targetPath).Directory;
                             _fileSystem.Directory.CreateDirectory(parent!.FullName);
 
-                            await using FileSystemStream targetFile = _fileSystem.File.Open(
-                                targetPath,
-                                FileMode.Create,
-                                FileAccess.ReadWrite
-                            );
-                            string patchPath = _fileSystem.Path.Combine(tempPatchDir, trueName);
-                            await using FileSystemStream entryStream = _fileSystem.File.OpenRead(patchPath);
-                            await entryStream.CopyToAsync(targetFile);
-
-                            if (!await ValidateFileHashAsync(targetFile, operation.FinalHash!))
+                            // Stage and verify beside the target, then atomically swap it in - the
+                            // extracted file already sits complete in tempPatchDir, but that may be on
+                            // a different volume, so copy it in next to the target first to make the
+                            // final swap a same-volume rename rather than a cross-volume copy.
+                            string swapPath = targetPath + ".newtemp";
+                            try
                             {
-                                throw new InvalidDataException(
-                                    $"File {targetFile.Name} does not match expected hash " +
-                                    $"{FormatHash(operation.FinalHash!)}."
-                                );
+                                string patchPath = _fileSystem.Path.Combine(tempPatchDir, trueName);
+                                await using (FileSystemStream swapFile = _fileSystem.File.Open(
+                                                 swapPath, FileMode.Create, FileAccess.ReadWrite))
+                                {
+                                    await using FileSystemStream entryStream = _fileSystem.File.OpenRead(patchPath);
+                                    await entryStream.CopyToAsync(swapFile);
+
+                                    if (!await ValidateFileHashAsync(swapFile, operation.FinalHash!))
+                                    {
+                                        throw new InvalidDataException(
+                                            $"File {trueName} does not match expected hash " +
+                                            $"{FormatHash(operation.FinalHash!)}."
+                                        );
+                                    }
+                                }
+
+                                await RetryOnFileLockAsync(
+                                    () => { _fileSystem.File.Move(swapPath, targetPath, true); return Task.CompletedTask; },
+                                    trueName, log);
+                            }
+                            finally
+                            {
+                                try { if (_fileSystem.File.Exists(swapPath)) _fileSystem.File.Delete(swapPath); }
+                                catch { /* best-effort cleanup */ }
                             }
                         }
                     }
@@ -497,8 +545,56 @@ public class Ksp2Patch : IDisposable
         return reader.ReadToEnd();
     }
 
+    /// <summary>
+    /// Retries an operation a few times with a short, increasing delay when it fails with an
+    /// IOException - antivirus mid-scan or the game itself still holding a handle on a file being
+    /// patched is common and almost always resolves within a second or two on its own. Without this,
+    /// a purely transient lock forces the same expensive whole-install rollback as a real failure.
+    /// </summary>
+    private static async Task RetryOnFileLockAsync(Func<Task> action, string fileDescription, Action<string>? log)
+    {
+        const int maxAttempts = 5;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                await action();
+                return;
+            }
+            catch (IOException) when (attempt < maxAttempts)
+            {
+                log?.Invoke($"{fileDescription} appears to be in use (attempt {attempt}/{maxAttempts}), retrying shortly...");
+                await Task.Delay(TimeSpan.FromMilliseconds(300 * attempt));
+            }
+        }
+    }
+
     private string NormalizeEntryPath(string path) =>
         path.Replace('\\', _fileSystem.Path.DirectorySeparatorChar).Replace('/', _fileSystem.Path.DirectorySeparatorChar);
+
+    /// <summary>
+    /// Combines <paramref name="baseDirectory"/> with a patch entry's (already-normalized) relative
+    /// path and asserts the result actually stays under that directory. Only the archive's own
+    /// whole-file checksum is verified upstream (ManifestReleasesFeed) - nothing otherwise stops a
+    /// corrupted or tampered manifest.json from naming an entry like "../../../Windows/System32/x"
+    /// and writing or deleting files outside the install directory entirely.
+    /// </summary>
+    private string ResolveContainedPath(string baseDirectory, string relativePath)
+    {
+        string fullBase = _fileSystem.Path.GetFullPath(baseDirectory);
+        string fullCombined = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine(fullBase, relativePath));
+
+        bool isContained = fullCombined.Equals(fullBase, StringComparison.OrdinalIgnoreCase) ||
+                            fullCombined.StartsWith(fullBase + _fileSystem.Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        if (!isContained)
+        {
+            throw new InvalidDataException(
+                $"Patch entry '{relativePath}' resolves outside of '{fullBase}'. Refusing to apply - " +
+                "this patch may be corrupted or tampered with.");
+        }
+
+        return fullCombined;
+    }
 
     private static bool ValidateFileHash(Stream stream, byte[] hash)
     {

--- a/Ksp2Redux.Tools.Launcher.Test/AppManifestTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/AppManifestTest.cs
@@ -1,0 +1,24 @@
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class AppManifestTest
+{
+    private static string FindAppManifestPath()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "Ksp2Redux.Tools.Launcher", "app.manifest");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException("Could not locate Ksp2Redux.Tools.Launcher/app.manifest by walking up from the test output directory.");
+    }
+
+    [Test]
+    public void AppManifest_DeclaresLongPathAware()
+    {
+        var content = File.ReadAllText(FindAppManifestPath());
+
+        Assert.That(content, Does.Contain("longPathAware"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/CacheServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/CacheServiceTest.cs
@@ -1,0 +1,48 @@
+using System.IO.Compression;
+using Ksp2Redux.Tools.Common.Service;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class CacheServiceTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+
+    private static (CacheService Service, MockFileSystem FileSystem, Mock<IZipFileService> ZipFileService) MakeService()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+        fs.Directory.CreateDirectory(fs.Path.GetTempPath());
+        var zipFileService = new Mock<IZipFileService>();
+        return (new CacheService(fs, zipFileService.Object), fs, zipFileService);
+    }
+
+    [Test]
+    public void RecursivelyCreateCache_ZipCreationFails_DeletesThePartialTempFile()
+    {
+        var (service, fs, zipFileService) = MakeService();
+        zipFileService.Setup(z => z.NewArchive(It.IsAny<Stream>(), It.IsAny<ZipArchiveMode>(), It.IsAny<bool>()))
+            .Throws(new IOException("disk full"));
+
+        Assert.Throws<IOException>(() => service.RecursivelyCreateCache(InstallDir));
+
+        var leftoverTempFiles = fs.Directory.EnumerateFiles(fs.Path.GetTempPath(), "uninstall-*.zip");
+        Assert.That(leftoverTempFiles, Is.Empty, "A failed snapshot must not leave a partial temp file behind.");
+    }
+
+    [Test]
+    public void RecursivelyRestoreCache_UninstallZipMissing_ThrowsCacheRestoreExceptionWithContext()
+    {
+        var (service, _, _) = MakeService();
+
+        var ex = Assert.Throws<CacheRestoreException>(() => service.RecursivelyRestoreCache(InstallDir));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Directory, Is.EqualTo(InstallDir));
+            Assert.That(ex.ExpectedFile, Is.EqualTo("uninstall.zip"));
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/CommunityTabViewModelTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/CommunityTabViewModelTest.cs
@@ -1,0 +1,47 @@
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels.Community;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class CommunityTabViewModelTest
+{
+    [Test]
+    public void SelectedNews_IdNoLongerInTheBackingList_FallsBackToEmptyInsteadOfThrowing()
+    {
+        var newsService = new Mock<INewsService>();
+        newsService.Setup(n => n.GetNews("stale-id")).Returns((News?)null);
+        var communityTabViewModel = new CommunityTabViewModel(newsService.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
+
+        communityTabViewModel.SetSelectedNewsId("stale-id");
+
+        Assert.That(communityTabViewModel.SelectedNews.Title, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void NewsVisible_NothingSelected_IsFalse()
+    {
+        var newsService = new Mock<INewsService>();
+        var communityTabViewModel = new CommunityTabViewModel(newsService.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
+
+        Assert.That(communityTabViewModel.NewsVisible, Is.False);
+    }
+
+    [Test]
+    public void SetSelectedNewsId_MatchingId_ShowsThatArticle()
+    {
+        var news = new News { Id = "abc", Title = "Hello" };
+        var newsService = new Mock<INewsService>();
+        newsService.Setup(n => n.GetNews("abc")).Returns(news);
+        var communityTabViewModel = new CommunityTabViewModel(newsService.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
+
+        communityTabViewModel.SetSelectedNewsId("abc");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(communityTabViewModel.NewsVisible, Is.True);
+            Assert.That(communityTabViewModel.SelectedNews.Title, Is.EqualTo("Hello"));
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DiagnosticInfoTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DiagnosticInfoTest.cs
@@ -1,0 +1,42 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class DiagnosticInfoTest
+{
+    [AvaloniaTest]
+    public async Task BuildDiagnosticInfo_ActiveInstallAndLogPresent_BundlesEverythingIntoOneBlock()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var settingsTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<SettingsTabViewModel>();
+
+        // Act
+        string diagnosticInfo = settingsTabViewModel.BuildDiagnosticInfo();
+
+        // Assert
+        Assert.That(diagnosticInfo, Does.Contain("KSP2 Redux Launcher v"));
+        Assert.That(diagnosticInfo, Does.Contain("Active install:"));
+        Assert.That(diagnosticInfo, Does.Contain("--- Recent log ---"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DownloadTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/DownloadTest.cs
@@ -124,7 +124,7 @@ public class DownloadTest
 
         ReleasePatch patch1Rollup = new()
         {
-            ChecksumSha256 = Convert.ToBase64String(SHA256.HashData(patch1RollupZipBytes)),
+            ChecksumSha256 = Convert.ToHexString(SHA256.HashData(patch1RollupZipBytes)),
             ReleasedAt = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Requires = new PatchRequirement { Version = null },
             Size = 10,

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ExternalLinkTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/ExternalLinkTest.cs
@@ -1,0 +1,108 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Community;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class ExternalLinkTest
+{
+    private static async Task<(MainWindowViewModel MainWindowViewModel, TopLevel TopLevel)> BootstrapAsync()
+    {
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        var mainWindowViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>();
+        MainWindow window = new MainWindow { DataContext = mainWindowViewModel };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return (mainWindowViewModel, TopLevel.GetTopLevel(window)!);
+    }
+
+    [AvaloniaTest]
+    public async Task LaunchExternalLinkAsync_MalformedUrl_ShowsFeedbackInsteadOfThrowing()
+    {
+        // Arrange
+        var (mainWindowViewModel, topLevel) = await BootstrapAsync();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await mainWindowViewModel.LaunchExternalLinkAsync(topLevel, "not a valid url");
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null, "A malformed link must not throw from the click handler.");
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Open Link", It.IsAny<string>(),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+
+    [AvaloniaTest]
+    public async Task LaunchExternalLinkAsync_RelativeUrl_ShowsFeedbackInsteadOfThrowing()
+    {
+        // Arrange - a link that fails Uri.TryCreate's absolute-URI requirement (e.g. a feed
+        // returning a site-relative path instead of a full URL).
+        var (mainWindowViewModel, topLevel) = await BootstrapAsync();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await mainWindowViewModel.LaunchExternalLinkAsync(topLevel, "/blog/post-1");
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null);
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Open Link", It.IsAny<string>(),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+
+    [AvaloniaTest]
+    public async Task CommunityTab_LaunchExternalLinkAsync_MalformedUrl_ShowsFeedbackInsteadOfThrowing()
+    {
+        // Arrange
+        var (_, topLevel) = await BootstrapAsync();
+        var communityTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<CommunityTabViewModel>();
+
+        // Act - an empty/malformed link, e.g. a news post with no Link, used to reach `new Uri("")`.
+        Exception? thrown = null;
+        try
+        {
+            await communityTabViewModel.LaunchExternalLinkAsync(topLevel, "");
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null);
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Open Link", It.IsAny<string>(),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/FeedRefreshFailureTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/FeedRefreshFailureTest.cs
@@ -1,0 +1,88 @@
+using System.Net.Http;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class FeedRefreshFailureTest
+{
+    private const string DefaultChannel = "beta";
+    private const string OtherChannel = "stable";
+
+    [AvaloniaTest]
+    public async Task RefreshFeeds_ManifestFetchThrows_ShowsWarningBannerUntilNextSuccessfulRefresh()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        ReleaseManifest MakeManifest(string channel) => new()
+        {
+            Channel = channel,
+            GeneratedAt = new DateTime(2020, 1, 4),
+            Patches = [],
+            SchemaVersion = 1,
+        };
+
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel))))
+            .ReturnsAsync(MakeManifest(DefaultChannel));
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel) == false)))
+            .ReturnsAsync(MakeManifest(OtherChannel));
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+        Assert.That(homeTabViewModel.FeedRefreshFailed, Is.False);
+
+        var warningText = window.GetVisualDescendants().OfType<Avalonia.Controls.TextBlock>()
+            .FirstOrDefault(t => t.Name == "FeedRefreshWarning");
+        Assert.That(warningText, Is.Not.Null);
+        Assert.That(warningText!.IsVisible, Is.False);
+
+        // Act - simulate the feed fetch failing on the next refresh (e.g. network drop)
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.IsAny<FeedInfo>()))
+            .ThrowsAsync(new HttpRequestException("network unreachable"));
+
+        await homeTabViewModel.RefreshFeedsCommand.ExecuteAsync(null);
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - banner shows while the feed is failing
+        Assert.That(homeTabViewModel.FeedRefreshFailed, Is.True);
+        Assert.That(warningText.IsVisible, Is.True);
+
+        // Act - the feed recovers on the following refresh
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel))))
+            .ReturnsAsync(MakeManifest(DefaultChannel));
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.Is<FeedInfo>(f => f.Filename.Contains(DefaultChannel) == false)))
+            .ReturnsAsync(MakeManifest(OtherChannel));
+
+        await homeTabViewModel.RefreshFeedsCommand.ExecuteAsync(null);
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - banner clears once refreshes succeed again
+        Assert.That(homeTabViewModel.FeedRefreshFailed, Is.False);
+        Assert.That(warningText.IsVisible, Is.False);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/LaunchGameRevalidationTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/LaunchGameRevalidationTest.cs
@@ -1,0 +1,56 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class LaunchGameRevalidationTest
+{
+    [AvaloniaTest]
+    public async Task LaunchGame_InstallExeRemovedSinceLastRefresh_ShowsCouldntLaunchInsteadOfCrashing()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        const string exePath = @"C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program 2\KSP2_x64.exe";
+        TestAppBuilder.FileSystem.File.Delete(exePath);
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await homeTabViewModel.LaunchGameCommand.ExecuteAsync(null);
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        // Assert
+        Assert.That(thrown, Is.Null);
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Launch", It.Is<string>(s => s.Contains("not detected")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/MainButtonTooltipTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/MainButtonTooltipTest.cs
@@ -1,0 +1,89 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class MainButtonTooltipTest
+{
+    [AvaloniaTest]
+    public async Task MainButton_NoInstallDetected_ShowsAnExplanatoryTooltipBoundOnTheActualButton()
+    {
+        // Arrange - no install registered at all, so the main button stays on its Launch-shaped
+        // disabled default. This is the state a reviewer flagged as having lost its "why is this
+        // disabled" tooltip when it was previously (over-)removed for repeating the button's label.
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+        var installButton = window.GetVisualDescendants().OfType<Button>().Single(b => b.Name == "InstallButton");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTabViewModel.MainButtonEnabled, Is.False);
+            Assert.That(homeTabViewModel.MainButtonTooltip, Does.Contain("not detected"));
+            Assert.That(ToolTip.GetTip(installButton), Is.EqualTo(homeTabViewModel.MainButtonTooltip),
+                "The button's actual ToolTip.Tip must be bound to MainButtonTooltip, not just set on the view model.");
+            Assert.That(ToolTip.GetShowOnDisabled(installButton), Is.True,
+                "A tooltip that only matters while disabled needs ShowOnDisabled, or it will never be seen.");
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task MainButton_ReadyToLaunch_HasNoTooltip()
+    {
+        // Arrange - a normal, enabled state shouldn't show a tooltip that just repeats the button's
+        // own label (the original, narrower complaint that led to the tooltip being removed entirely).
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        // No newer release than what's already installed, so the version dropdown defaults to the
+        // synthetic "installed" entry and the button lands on its enabled Launch state.
+        TestAppBuilder.ManifestReleasesFeedProviderService
+            .Setup(m => m.GetManifest(It.IsAny<FeedInfo>()))
+            .ReturnsAsync((FeedInfo f) => new ReleaseManifest
+            {
+                Channel = f.Filename.Split('-', '.')[1],
+                GeneratedAt = new DateTime(2020, 1, 4),
+                Patches = [],
+                SchemaVersion = 1,
+            });
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTabViewModel.MainButtonEnabled, Is.True);
+            Assert.That(homeTabViewModel.MainButtonTooltip, Is.Null.Or.Empty);
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SettingsInputHardeningTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SettingsInputHardeningTest.cs
@@ -1,0 +1,94 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class SettingsInputHardeningTest
+{
+    private static async Task<SettingsTabViewModel> BootstrapAsync()
+    {
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        return TestAppBuilder.ServiceProvider.GetRequiredService<SettingsTabViewModel>();
+    }
+
+    [AvaloniaTest]
+    public async Task RemoveSelectedInstall_Declined_KeepsTheInstall()
+    {
+        // Arrange
+        var settingsTabViewModel = await BootstrapAsync();
+        var ksp2InstallService = TestAppBuilder.ServiceProvider.GetRequiredService<IKsp2InstallService>();
+        ksp2InstallService.AddInstall(@"C:\Other\KSP2_x64.exe", "Second install");
+
+        TestAppBuilder.MessageBoxService.Setup(m => m.ShowMessageBoxAsOwnedAsync(
+                "Confirm", It.IsAny<string>(), It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()))
+            .ReturnsAsync(ButtonResult.No);
+
+        var countBefore = ksp2InstallService.Entries.Count;
+
+        // Act
+        await settingsTabViewModel.RemoveSelectedInstallCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.That(ksp2InstallService.Entries, Has.Count.EqualTo(countBefore));
+    }
+
+    [AvaloniaTest]
+    public async Task RemoveSelectedInstall_Confirmed_RemovesTheInstall()
+    {
+        // Arrange
+        var settingsTabViewModel = await BootstrapAsync();
+        var ksp2InstallService = TestAppBuilder.ServiceProvider.GetRequiredService<IKsp2InstallService>();
+        ksp2InstallService.AddInstall(@"C:\Other\KSP2_x64.exe", "Second install");
+
+        TestAppBuilder.MessageBoxService.Setup(m => m.ShowMessageBoxAsOwnedAsync(
+                "Confirm", It.IsAny<string>(), It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()))
+            .ReturnsAsync(ButtonResult.Yes);
+
+        var countBefore = ksp2InstallService.Entries.Count;
+
+        // Act
+        await settingsTabViewModel.RemoveSelectedInstallCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.That(ksp2InstallService.Entries, Has.Count.EqualTo(countBefore - 1));
+    }
+
+    [AvaloniaTest]
+    public async Task AddInstall_AlreadyInProgress_ReturnsWithoutTouchingTheFilePicker()
+    {
+        // Arrange - simulate a fast double-click by marking the flow as already in progress.
+        var settingsTabViewModel = await BootstrapAsync();
+        settingsTabViewModel.IsAddingInstall = true;
+
+        // Act
+        await settingsTabViewModel.AddInstallCommand.ExecuteAsync(null);
+
+        // Assert - the re-entrancy guard returned early, so the file-picker failure path
+        // (which would show this dialog, since there's no real window in this test) never ran.
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Error!", It.Is<string>(s => s.Contains("file picker")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SilentFailureVisibilityTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/SilentFailureVisibilityTest.cs
@@ -1,0 +1,47 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class SilentFailureVisibilityTest
+{
+    [AvaloniaTest]
+    public async Task UpdateLauncher_ThrowingUnexpectedly_ShowsFailureDialogInsteadOfFailingSilently()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        // Act
+        await homeTabViewModel.UpdateLauncher();
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - the failure surfaces as a dialog, not just a log line
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+            "Update Failed!",
+            It.Is<string>(s => s.Contains("boom")),
+            It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/TestAppBuilder.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/TestAppBuilder.cs
@@ -26,6 +26,7 @@ public static class TestAppBuilder
     public static Mock<IUpdateService> UpdateService { get; private set; } = null!;
     public static Mock<IMessageBoxService> MessageBoxService { get; private set; } = null!;
     public static Mock<IOperatingSystemService> OperatingSystemService { get; private set; } = null!;
+    public static Mock<IDiskSpaceService> DiskSpaceService { get; private set; } = null!;
 
     public static IServiceProvider ServiceProvider { get; set; } = null!;
 
@@ -56,6 +57,8 @@ public static class TestAppBuilder
         OperatingSystemService = new();
         // Fully mocked for now, but could be tested if Http, Process and RuntimeInfo are separated in separated mockable interfaces
         UpdateService = new();
+        DiskSpaceService = new();
+        DiskSpaceService.Setup(d => d.GetAvailableFreeSpace(It.IsAny<string>())).Returns(long.MaxValue);
 
         ServiceCollection serviceCollection = new();
         serviceCollection.AddSingleton<MainWindowViewModel>();
@@ -82,7 +85,8 @@ public static class TestAppBuilder
         serviceCollection.AddSingleton(UpdateService.Object);
         serviceCollection.AddSingleton<IKsp2DetectorService, Ksp2DetectorService>(); 
         serviceCollection.AddSingleton(MessageBoxService.Object); 
-        serviceCollection.AddSingleton(OperatingSystemService.Object); 
+        serviceCollection.AddSingleton(OperatingSystemService.Object);
+        serviceCollection.AddSingleton(DiskSpaceService.Object);
         ServiceProvider = serviceCollection.BuildServiceProvider();
     }
 }

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UninstallFailureTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UninstallFailureTest.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class UninstallFailureTest
+{
+    [AvaloniaTest]
+    public async Task UninstallRedux_RestoreCacheThrows_ShowsErrorInsteadOfCrashing()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        const string installDir = @"C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program 2";
+        TestAppBuilder.FileSystem.File.WriteAllBytes(TestAppBuilder.FileSystem.Path.Combine(installDir, "uninstall.zip"), [0x00]);
+        TestAppBuilder.ZipFileService
+            .Setup(z => z.OpenRead(TestAppBuilder.FileSystem.Path.Combine(installDir, "uninstall.zip")))
+            .Throws(new IOException("uninstall.zip is locked by another process"));
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var settingsTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<SettingsTabViewModel>();
+
+        // Act
+        Exception? thrown = null;
+        try
+        {
+            await settingsTabViewModel.UninstallRedux();
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert
+        Assert.That(thrown, Is.Null, "Uninstall failure must not propagate as an unhandled exception.");
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Error!",
+                It.Is<string>(s => s.Contains("Couldn't uninstall Redux") && s.Contains("locked by another process")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UnknownGameVersionTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/UnknownGameVersionTest.cs
@@ -1,0 +1,54 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class UnknownGameVersionTest
+{
+    [AvaloniaTest]
+    public void UpdateMainButtonState_GameVersionCouldNotBeDetected_DisablesTheMainButton()
+    {
+        // Arrange - IsValid only confirms the exe exists; it says nothing about whether we could
+        // read its version. A stock install whose VersionID type is missing an expected field (a
+        // game update that changed field names, an unsupported distribution, etc.) used to leave
+        // Install/Update enabled with an unknown "from" version - see issue #26.
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        // Override the module set up by MockKsp2StockSteamInstall with one whose VersionID type is
+        // missing VERSION_TEXT, so FromVersionIDType throws and detection fails.
+        var brokenModule = TestHelpers.GenerateMockVersionID(("DEBUG_INFO", "BUILD_INFO"));
+        TestAppBuilder.ModuleDefinitionService
+            .Setup(m => m.ReadModule(
+                @"C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program 2\KSP2_x64_Data\Managed\Assembly-CSharp.dll"))
+            .Returns(brokenModule.module);
+
+        // Act
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var homeTabViewModel = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTabViewModel.MainButtonEnabled, Is.False,
+                "Install/Update/Launch must not be reachable when the current game version is unknown.");
+            Assert.That(homeTabViewModel.MainButtonTooltip, Does.Contain("Couldn't detect the installed game version"));
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionDetectionFailureTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/VersionDetectionFailureTest.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class VersionDetectionFailureTest
+{
+    [AvaloniaTest]
+    public async Task Startup_GameVersionDetectionThrows_ShowsPlainLanguageDialogInsteadOfRawException()
+    {
+        // Arrange
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestHelpers.MockKsp2StockSteamInstall();
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        // Override the version-reading mock (set up by MockKsp2StockSteamInstall) to blow up instead.
+        TestAppBuilder.ModuleDefinitionService
+            .Setup(m => m.ReadModule(It.IsAny<string>()))
+            .Throws(new InvalidOperationException("corrupt PE header"));
+
+        // Act
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        // Assert - the user gets a plain-language explanation, not a dumped exception type/stack trace.
+        TestAppBuilder.MessageBoxService.Verify(m => m.ShowMessageBoxAsOwnedAsync(
+                "Couldn't Detect Game Version",
+                It.Is<string>(s => s.Contains("couldn't figure out") && !s.Contains("InvalidOperationException") && !s.Contains("corrupt PE header")),
+                It.IsAny<ButtonEnum>(), It.IsAny<Icon>(), It.IsAny<object>(), It.IsAny<WindowStartupLocation>()),
+            Times.Once);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceDiskSpaceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceDiskSpaceTest.cs
@@ -1,0 +1,77 @@
+using Ksp2Redux.Tools.Common.Service;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class InstallPlanServiceDiskSpaceTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+
+    private static (InstallPlanService Service, Mock<IDiskSpaceService> DiskSpace, MockFileSystem Fs) MakeService()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+
+        var cacheService = new Mock<ICacheService>();
+        var environmentProvider = new MockEnvironmentProvider();
+        var assemblyService = new Mock<IAssemblyService>();
+        var moduleDefinitionService = new Mock<IModuleDefinitionService>();
+        var zipFileService = new Mock<IZipFileService>();
+        var diskSpace = new Mock<IDiskSpaceService>();
+
+        var service = new InstallPlanService(fs, cacheService.Object, environmentProvider, assemblyService.Object,
+            moduleDefinitionService.Object, zipFileService.Object, diskSpace.Object);
+        return (service, diskSpace, fs);
+    }
+
+    [Test]
+    public void ApplyToFolder_NotEnoughFreeSpace_ThrowsBeforeTouchingAnyStep()
+    {
+        var (service, diskSpace, _) = MakeService();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(InstallDir)).Returns(1024); // basically nothing
+
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, _) => Task.FromResult("unused"), "big patch", downloadSize: 10L * 1024 * 1024 * 1024); // 10 GB
+
+        Assert.That(async () => await service.ApplyToFolder(plan, InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None),
+            Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public async Task ApplyToFolder_EnoughFreeSpace_DoesNotThrowFromSpaceCheck()
+    {
+        var (service, diskSpace, _) = MakeService();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(InstallDir)).Returns(100L * 1024 * 1024 * 1024); // 100 GB
+
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, ct) => Task.FromResult(InstallDir), "small patch", downloadSize: 1024);
+
+        // A missing/invalid patch file will fail later in Ksp2Patch.FromFile - that's fine, it means the
+        // space check itself let it through.
+        Exception? thrown = null;
+        try { await service.ApplyToFolder(plan, InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None); }
+        catch (Exception ex) { thrown = ex; }
+
+        Assert.That(thrown?.Message ?? "", Does.Not.Contain("disk space"));
+    }
+
+    [Test]
+    public async Task ApplyToFolder_DiskSpaceUnknown_SkipsCheckAndProceeds()
+    {
+        var (service, diskSpace, _) = MakeService();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(InstallDir)).Returns((long?)null);
+
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, _) => Task.FromResult("unused"), "big patch", downloadSize: 10L * 1024 * 1024 * 1024);
+
+        // Should not throw due to disk space (unknown => skip check); it'll fail later for other reasons instead.
+        Exception? thrown = null;
+        try { await service.ApplyToFolder(plan, InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None); }
+        catch (Exception ex) { thrown = ex; }
+
+        Assert.That(thrown?.Message ?? "", Does.Not.Contain("disk space"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceRollbackTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/InstallPlanServiceRollbackTest.cs
@@ -1,0 +1,93 @@
+using Ksp2Redux.Tools.Common.Service;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class InstallPlanServiceRollbackTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+    private const string PatchPath = @"C:\downloads\corrupt.patch";
+
+    private static (InstallPlanService Service, Mock<ICacheService> CacheService, MockFileSystem Fs)
+        MakeService(Mock<IZipFileService> zipFileService)
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+        fs.Directory.CreateDirectory(fs.Path.GetDirectoryName(PatchPath)!);
+        fs.File.WriteAllBytes(PatchPath, [0x01]);
+
+        var cacheService = new Mock<ICacheService>();
+        var environmentProvider = new MockEnvironmentProvider();
+        var assemblyService = new Mock<IAssemblyService>();
+        var moduleDefinitionService = new Mock<IModuleDefinitionService>();
+        var diskSpace = new Mock<IDiskSpaceService>();
+        diskSpace.Setup(d => d.GetAvailableFreeSpace(It.IsAny<string>())).Returns(long.MaxValue);
+
+        var service = new InstallPlanService(fs, cacheService.Object, environmentProvider, assemblyService.Object,
+            moduleDefinitionService.Object, zipFileService.Object, diskSpace.Object);
+        return (service, cacheService, fs);
+    }
+
+    private static InstallPlan MakeCorruptPatchPlan()
+    {
+        var plan = new InstallPlan();
+        plan.ApplyPatchFile((_, _, _) => Task.FromResult(PatchPath), "corrupt patch");
+        return plan;
+    }
+
+    [Test]
+    public async Task ApplyToFolder_PatchApplyFailsWithSnapshotAvailable_RollsBackAndThrowsInstallFailedException()
+    {
+        var zipFileService = new Mock<IZipFileService>();
+        zipFileService.Setup(z => z.OpenRead(PatchPath)).Throws(new IOException("archive is corrupt"));
+
+        var (service, cacheService, fs) = MakeService(zipFileService);
+        fs.File.WriteAllBytes(fs.Path.Combine(InstallDir, "uninstall.zip"), [0x00]); // a snapshot exists
+
+        var ex = Assert.ThrowsAsync<InstallFailedException>(async () =>
+            await service.ApplyToFolder(MakeCorruptPatchPlan(), InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None));
+
+        Assert.That(ex!.RolledBack, Is.True);
+        Assert.That(ex.Message, Does.Contain("rolled back"));
+        Assert.That(ex.InnerException, Is.InstanceOf<IOException>());
+        cacheService.Verify(c => c.RecursivelyRestoreCache(InstallDir, true), Times.Once);
+    }
+
+    [Test]
+    public async Task ApplyToFolder_PatchApplyFailsAndRollbackAlsoFails_ThrowsWithBothFailuresDescribed()
+    {
+        var zipFileService = new Mock<IZipFileService>();
+        zipFileService.Setup(z => z.OpenRead(PatchPath)).Throws(new IOException("archive is corrupt"));
+
+        var (service, cacheService, fs) = MakeService(zipFileService);
+        fs.File.WriteAllBytes(fs.Path.Combine(InstallDir, "uninstall.zip"), [0x00]);
+        cacheService.Setup(c => c.RecursivelyRestoreCache(InstallDir, true))
+            .Throws(new IOException("disk full while restoring"));
+
+        var ex = Assert.ThrowsAsync<InstallFailedException>(async () =>
+            await service.ApplyToFolder(MakeCorruptPatchPlan(), InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None));
+
+        Assert.That(ex!.RolledBack, Is.False);
+        Assert.That(ex.Message, Does.Contain("archive is corrupt"));
+        Assert.That(ex.Message, Does.Contain("disk full while restoring"));
+    }
+
+    [Test]
+    public async Task ApplyToFolder_PatchApplyFailsWithNoSnapshot_RethrowsOriginalExceptionUnwrapped()
+    {
+        var zipFileService = new Mock<IZipFileService>();
+        zipFileService.Setup(z => z.OpenRead(PatchPath)).Throws(new IOException("archive is corrupt"));
+
+        var (service, cacheService, _) = MakeService(zipFileService);
+        // No uninstall.zip created - nothing to roll back to yet.
+
+        var ex = Assert.ThrowsAsync<IOException>(async () =>
+            await service.ApplyToFolder(MakeCorruptPatchPlan(), InstallDir, _ => { }, (_, _) => { }, (_, _) => { }, CancellationToken.None));
+
+        Assert.That(ex!.Message, Is.EqualTo("archive is corrupt"));
+        cacheService.Verify(c => c.RecursivelyRestoreCache(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2DetectorServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2DetectorServiceTest.cs
@@ -1,0 +1,61 @@
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class Ksp2DetectorServiceTest
+{
+    private const string SteamRoot = @"C:\Program Files (x86)\Steam";
+
+    private static (Ksp2DetectorService Service, MockFileSystem FileSystem, Mock<ILogService> Log) MakeService()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        var env = new MockEnvironmentProvider();
+        var os = new Mock<IOperatingSystemService>();
+        os.Setup(o => o.IsLinux()).Returns(false);
+        var log = new Mock<ILogService>();
+        fs.Directory.CreateDirectory(SteamRoot);
+        return (new Ksp2DetectorService(fs, env, os.Object, log.Object), fs, log);
+    }
+
+    [Test]
+    public void DetectKsp2InstallLocation_LibraryFoldersVdfExistsButParsesToNothing_LogsAWarning()
+    {
+        var (service, fs, log) = MakeService();
+        // A file caught mid-write by Steam - present, but the regex finds no "path" entries in it.
+        fs.Directory.CreateDirectory(fs.Path.Combine(SteamRoot, "steamapps"));
+        fs.File.WriteAllText(fs.Path.Combine(SteamRoot, "steamapps", "libraryfolders.vdf"), "not valid vdf content");
+
+        service.DetectKsp2InstallLocation();
+
+        log.Verify(l => l.Warn(
+            It.Is<string>(s => s.Contains("libraryfolders.vdf") && s.Contains("no library paths")),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public void DetectKsp2InstallLocation_AppManifestExistsButInstallDirUnparseable_LogsAWarning()
+    {
+        var (service, fs, log) = MakeService();
+        fs.Directory.CreateDirectory(fs.Path.Combine(SteamRoot, "steamapps"));
+        fs.File.WriteAllText(fs.Path.Combine(SteamRoot, "steamapps", "appmanifest_954850.acf"), "not valid acf content");
+
+        service.DetectKsp2InstallLocation();
+
+        log.Verify(l => l.Warn(
+            It.Is<string>(s => s.Contains("appmanifest_954850.acf") && s.Contains("installdir")),
+            It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public void DetectKsp2InstallLocation_NoLibraryFoldersVdfAtAll_DoesNotLogAWarning()
+    {
+        // Not having extra libraries configured is the normal case and shouldn't look like a parse failure.
+        var (service, fs, log) = MakeService();
+
+        service.DetectKsp2InstallLocation();
+
+        log.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallRowViewModelValidationTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallRowViewModelValidationTest.cs
@@ -1,0 +1,83 @@
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class Ksp2InstallRowViewModelValidationTest
+{
+    private const string ValidExePath = @"C:\Games\Ksp2\KSP2_x64.exe";
+
+    private static (Ksp2InstallRowViewModel Row, MockFileSystem FileSystem) MakeRow(string exePath, string steamAppId)
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(@"C:\Games\Ksp2");
+        fs.File.WriteAllBytes(ValidExePath, [0x00]);
+
+        var entry = new Ksp2InstallEntry
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            ExePath = exePath,
+            ReleaseChannel = "beta",
+            SteamAppId = steamAppId,
+        };
+        var ksp2InstallService = new Mock<IKsp2InstallService>();
+        var row = new Ksp2InstallRowViewModel(fs, ksp2InstallService.Object, entry, isActive: true);
+        return (row, fs);
+    }
+
+    [Test]
+    public void ExePath_PointsToRealKsp2Exe_HasNoError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+        Assert.That(row.ExePathError, Is.Null);
+    }
+
+    [Test]
+    public void ExePath_WrongFileName_HasError()
+    {
+        var (row, fs) = MakeRow(ValidExePath, "954850");
+        fs.File.WriteAllBytes(@"C:\Games\Ksp2\NotTheGame.exe", [0x00]);
+
+        row.ExePath = @"C:\Games\Ksp2\NotTheGame.exe";
+
+        Assert.That(row.ExePathError, Does.Contain("KSP2_x64.exe"));
+    }
+
+    [Test]
+    public void ExePath_DoesNotExist_HasError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+
+        row.ExePath = @"C:\Games\Ksp2\Missing\KSP2_x64.exe";
+
+        Assert.That(row.ExePathError, Does.Contain("doesn't exist"));
+    }
+
+    [Test]
+    public void SteamAppId_Numeric_HasNoError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+        Assert.That(row.SteamAppIdError, Is.Null);
+    }
+
+    [Test]
+    public void SteamAppId_Empty_HasNoError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "");
+        Assert.That(row.SteamAppIdError, Is.Null);
+    }
+
+    [Test]
+    public void SteamAppId_NonNumeric_HasError()
+    {
+        var (row, _) = MakeRow(ValidExePath, "954850");
+
+        row.SteamAppId = "not-a-number";
+
+        Assert.That(row.SteamAppIdError, Does.Contain("numeric"));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2InstallServiceTest.cs
@@ -19,9 +19,10 @@ public class Ksp2InstallServiceTest
         fileSystem.SetupGet(fs => fs.Path).Returns(path.Object);
 
         var moduleDef = new Mock<IModuleDefinitionService>();
+        var logService = new Mock<ILogService>();
         var config = new LauncherConfig { StoragePath = "/tmp/cfg.json" };
         cfg.SetupGet(c => c.Config).Returns(config);
-        var svc = new Ksp2InstallService(cfg.Object, fileSystem.Object, moduleDef.Object);
+        var svc = new Ksp2InstallService(cfg.Object, fileSystem.Object, moduleDef.Object, logService.Object);
         return (svc, cfg, config);
     }
 

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2PatchIdempotentRetryTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2PatchIdempotentRetryTest.cs
@@ -1,0 +1,61 @@
+using System.IO.Abstractions;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Common.Service;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class Ksp2PatchIdempotentRetryTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+
+    [Test]
+    public async Task AsyncApply_FileAlreadyMatchesExpectedResult_SkipsWithoutTouchingArchiveEntry()
+    {
+        // Arrange - simulate retrying a plan after a previous attempt already finished this one file
+        // (e.g. a different operation in the same step failed and the plan is being retried).
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+
+        byte[] alreadyAppliedContent = "already the correct final content"u8.ToArray();
+        string finalHashB64 = Convert.ToBase64String(SHA256.HashData(alreadyAppliedContent));
+        fs.File.WriteAllBytes(fs.Path.Combine(InstallDir, "already-done.txt"), alreadyAppliedContent);
+
+        string manifestJson = $$"""
+            {
+              "operations": [
+                {
+                  "fileName": "already-done.txt",
+                  "action": 1,
+                  "originalHash": null,
+                  "finalHash": "{{finalHashB64}}"
+                }
+              ]
+            }
+            """;
+
+        var archive = new Mock<IZipArchive>();
+        archive.SetupGet(a => a.Mode).Returns(ZipArchiveMode.Read);
+
+        var manifestEntry = new Mock<IZipArchiveEntry>();
+        manifestEntry.Setup(e => e.Open()).Returns(new MemoryStream(Encoding.UTF8.GetBytes(manifestJson)));
+        archive.Setup(a => a.GetEntry("manifest.json")).Returns(manifestEntry.Object);
+
+        var fileEntry = new Mock<IZipArchiveEntry>();
+        archive.Setup(a => a.GetEntry("already-done.txt")).Returns(fileEntry.Object);
+
+        var patch = new Ksp2Patch(fs, archive.Object);
+        var environmentProvider = new MockEnvironmentProvider();
+
+        // Act
+        await patch.AsyncApply(environmentProvider, InstallDir);
+
+        // Assert - the file was recognized as already matching the expected result and left alone,
+        // rather than being reopened/rewritten by the (redundant) copy-from-patch step.
+        Assert.That(fs.File.ReadAllBytes(fs.Path.Combine(InstallDir, "already-done.txt")), Is.EqualTo(alreadyAppliedContent));
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/Ksp2PatchPathTraversalTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/Ksp2PatchPathTraversalTest.cs
@@ -1,0 +1,60 @@
+using System.IO.Abstractions;
+using System.IO.Compression;
+using System.Text;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Common.Service;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class Ksp2PatchPathTraversalTest
+{
+    private const string InstallDir = @"C:\Games\Ksp2";
+
+    private static (Ksp2Patch Patch, MockFileSystem Fs, Mock<IZipArchiveEntry> MaliciousEntry) MakeMaliciousPatch(string maliciousFileName)
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(InstallDir);
+
+        string manifestJson = $$"""
+            {
+              "operations": [
+                {
+                  "fileName": "{{maliciousFileName.Replace("\\", "\\\\")}}",
+                  "action": 1,
+                  "originalHash": null,
+                  "finalHash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                }
+              ]
+            }
+            """;
+
+        var archive = new Mock<IZipArchive>();
+        archive.SetupGet(a => a.Mode).Returns(ZipArchiveMode.Read);
+
+        var manifestEntry = new Mock<IZipArchiveEntry>();
+        manifestEntry.Setup(e => e.Open()).Returns(new MemoryStream(Encoding.UTF8.GetBytes(manifestJson)));
+        archive.Setup(a => a.GetEntry("manifest.json")).Returns(manifestEntry.Object);
+
+        var maliciousEntry = new Mock<IZipArchiveEntry>();
+        archive.Setup(a => a.GetEntry(maliciousFileName)).Returns(maliciousEntry.Object);
+
+        var patch = new Ksp2Patch(fs, archive.Object);
+        return (patch, fs, maliciousEntry);
+    }
+
+    [Test]
+    public void AsyncApply_EntryNameEscapesWithParentDirectorySegments_ThrowsAndNeverExtracts()
+    {
+        var (patch, fs, maliciousEntry) = MakeMaliciousPatch(@"..\..\..\evil.txt");
+        var environmentProvider = new MockEnvironmentProvider();
+
+        Assert.ThrowsAsync<InvalidDataException>(async () =>
+            await patch.AsyncApply(environmentProvider, InstallDir));
+
+        // The containment check must reject the entry before any extraction is even attempted.
+        maliciousEntry.Verify(e => e.ExtractToFile(It.IsAny<IFileSystem>(), It.IsAny<string>()), Times.Never);
+        Assert.That(fs.File.Exists(@"C:\evil.txt"), Is.False);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/LauncherConfigServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LauncherConfigServiceTest.cs
@@ -2,6 +2,7 @@
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
 using Moq;
+using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.Test;
 
@@ -91,7 +92,7 @@ public class LauncherConfigServiceTest
         
         // Act Assert
         Assert.That(
-            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object),
+            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object),
             Throws.Exception);
         directory.Verify(d => d.CreateDirectory("incorrect combined path"), Times.Never,
             "Tried to create a directory for the config when appdata didn't exist");
@@ -132,7 +133,7 @@ public class LauncherConfigServiceTest
         
         // Act Assert
         Assert.That(
-            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object),
+            () => new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object),
             Throws.Exception);
         directory.Verify(d => d.CreateDirectory("incorrect combined path"), Times.Never,
             "Tried to create a directory for the config when appdata didn't exist");
@@ -166,7 +167,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         
         // Assert
         file.Verify(f => f.WriteAllText("/appdata/Ksp2Redux/redux-launcher-config.json", It.IsAny<string>()), Times.Once);
@@ -199,7 +200,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         
         // Assert
         file.Verify(f => f.WriteAllText("/appdata/Ksp2Redux/redux-launcher-config.json", It.IsAny<string>()), Times.Once);
@@ -232,7 +233,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
         
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         
         // Assert
         file.Verify(f => f.WriteAllText("/appdata/Ksp2Redux/redux-launcher-config.json", It.IsAny<string>()), Times.Once);
@@ -265,7 +266,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
 
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
 
         // Assert: legacy single-install was migrated to the new schema.
         var cfg = launcherConfigService.Config;
@@ -308,7 +309,7 @@ public class LauncherConfigServiceTest
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
 
         // Act
-        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+        LauncherConfigService launcherConfigService = new LauncherConfigService(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
 
         // Assert
         var cfg = launcherConfigService.Config;
@@ -320,7 +321,7 @@ public class LauncherConfigServiceTest
     
     // Save
     [Test]
-    public void Save_NullStoragePathDirectoryName_ThrowsException()
+    public void Save_NullStoragePathDirectoryName_ReportsFailureInsteadOfThrowing()
     {
         // Arrange
         Mock<IEnvironmentProvider> environmentProvider  = new();
@@ -328,6 +329,7 @@ public class LauncherConfigServiceTest
         Mock<IDirectory> directory = new();
         Mock<IFile> file = new();
         Mock<IFileSystem> fileSystem = new();
+        Mock<ILogService> log = new();
 
         // Pass constructor quickly without issues
         environmentProvider.Setup(ep => ep.GetFolderPath(Environment.SpecialFolder.LocalApplicationData))
@@ -337,11 +339,15 @@ public class LauncherConfigServiceTest
         path.Setup(p => p.Combine("/appdata/Ksp2Redux", "redux-launcher-config.json"))
             .Returns("configFilePath");
         file.Setup(f => f.ReadAllText("configFilePath")).Returns(simpleLauncherConfigJson);
-        
+        // simpleLauncherConfigJson is legacy-schema, so construction triggers a migration Save() too -
+        // give that one a valid directory so only the explicit Save() below hits the failure path.
+        path.Setup(p => p.GetDirectoryName("configFilePath"))
+            .Returns("/appdata/Ksp2Redux");
+
         // Test method
         path.Setup(p => p.GetDirectoryName("storage path"))
             .Returns((string?)null);
-        
+
         fileSystem.SetupGet(fs => fs.Path).Returns(path.Object);
         fileSystem.SetupGet(fs => fs.Directory).Returns(directory.Object);
         fileSystem.SetupGet(fs => fs.File).Returns(file.Object);
@@ -349,7 +355,7 @@ public class LauncherConfigServiceTest
         LauncherConfigService launcherConfigService = null!;
         try
         {
-            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, log.Object);
         }
         catch(Exception e)
         {
@@ -360,13 +366,15 @@ public class LauncherConfigServiceTest
         {
             StoragePath = "storage path"
         };
-        
-        // Act Assert
-        Assert.That(() => launcherConfigService.Save(), Throws.Exception);
-        directory.Verify(d => d.CreateDirectory(It.IsNotIn("/appdata/Ksp2Redux")), Times.Never, 
+
+        // Act Assert - a failed save must never throw back into a UI data-binding callback; it should
+        // be logged instead so the app stays up (see the "stop the crashes" hardening pass).
+        Assert.That(() => launcherConfigService.Save(), Throws.Nothing);
+        log.Verify(l => l.Error(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        directory.Verify(d => d.CreateDirectory(It.IsNotIn("/appdata/Ksp2Redux")), Times.Never,
             "Tried creating a directory when IPath.GetDirectoryName returned null");
-        file.Verify(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never,
-            "Tried creating a directory when IPath.GetDirectoryName returned null");
+        file.Verify(f => f.WriteAllText("storage path", It.IsAny<string>()), Times.Never,
+            "Tried writing to storage path when IPath.GetDirectoryName returned null");
     }
     
     [Test]
@@ -402,7 +410,7 @@ public class LauncherConfigServiceTest
         LauncherConfigService launcherConfigService = null!;
         try
         {
-            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<ILogService>().Object);
+            launcherConfigService = new(fileSystem.Object, environmentProvider.Object, new Mock<IMessageBoxService>().Object, new Mock<ILogService>().Object);
         }
         catch(Exception e)
         {

--- a/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
@@ -119,9 +119,15 @@ public class LogServiceTest
         var (fs, env) = BuildEnv();
         var log = new LogService(fs, env, maxLogFileSizeBytes: 200);
 
-        // Push the file past the tiny test cap, then keep writing.
+        // Push the file past the tiny test cap. Depending on how long the header's OS-description
+        // line happens to be on the host running the test, the cap might already be exceeded before
+        // this call (in which case the "reached cap" warning is written here and this line is
+        // skipped) or only after it (in which case this line is written and the warning is
+        // deferred to the next call) - so a second call is needed to guarantee the warning has
+        // been written before taking the "settled" size snapshot below.
         log.Info(new string('x', 250));
-        var sizeAfterCapHit = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
+        log.Info("may or may not reach disk depending on header length, don't assert on it");
+        var sizeAfterCapAndWarning = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
 
         log.Info("this line must not reach disk");
         log.Info("neither must this one");
@@ -131,9 +137,10 @@ public class LogServiceTest
         var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
         Assert.Multiple(() =>
         {
-            Assert.That(sizeAfterMoreWrites, Is.EqualTo(sizeAfterCapHit), "No further lines should be written once the cap is reached.");
+            Assert.That(sizeAfterMoreWrites, Is.EqualTo(sizeAfterCapAndWarning), "No further lines should be written once the cap is reached.");
             Assert.That(contents, Does.Contain("Log file reached"));
             Assert.That(contents, Does.Not.Contain("this line must not reach disk"));
+            Assert.That(contents, Does.Not.Contain("neither must this one"));
         });
     }
 

--- a/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
@@ -60,6 +60,19 @@ public class LogServiceTest
     }
 
     [Test]
+    public void Info_TagsEachLineWithProcessId_SoAPastedFragmentIsSelfDescribing()
+    {
+        var (fs, env) = BuildEnv();
+        using var log = new LogService(fs, env);
+
+        log.Info("hello world");
+        log.Dispose();
+
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.That(contents, Does.Contain($"[pid={env.ProcessId}]"));
+    }
+
+    [Test]
     public void Error_WritesExceptionDetailsToLogFile()
     {
         var (fs, env) = BuildEnv();

--- a/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/LogServiceTest.cs
@@ -101,6 +101,61 @@ public class LogServiceTest
     }
 
     [Test]
+    public void Write_LogFileExceedsSizeCap_StopsWritingFurtherLinesToDisk()
+    {
+        var (fs, env) = BuildEnv();
+        var log = new LogService(fs, env, maxLogFileSizeBytes: 200);
+
+        // Push the file past the tiny test cap, then keep writing.
+        log.Info(new string('x', 250));
+        var sizeAfterCapHit = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
+
+        log.Info("this line must not reach disk");
+        log.Info("neither must this one");
+
+        var sizeAfterMoreWrites = fs.FileInfo.New(log.CurrentLogFilePath!).Length;
+        log.Dispose();
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(sizeAfterMoreWrites, Is.EqualTo(sizeAfterCapHit), "No further lines should be written once the cap is reached.");
+            Assert.That(contents, Does.Contain("Log file reached"));
+            Assert.That(contents, Does.Not.Contain("this line must not reach disk"));
+        });
+    }
+
+    [Test]
+    public void Debug_BelowDefaultMinimumLevel_IsNotWrittenToLogFile()
+    {
+        var (fs, env) = BuildEnv();
+        using var log = new LogService(fs, env);
+
+        log.Debug("verbose detail");
+        log.Info("normal message");
+        log.Dispose();
+
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(contents, Does.Not.Contain("verbose detail"));
+            Assert.That(contents, Does.Contain("normal message"));
+        });
+    }
+
+    [Test]
+    public void Debug_MinimumLevelLoweredToDebug_IsWrittenToLogFile()
+    {
+        var (fs, env) = BuildEnv();
+        using var log = new LogService(fs, env) { MinimumLevel = LogLevel.Debug };
+
+        log.Debug("verbose detail");
+        log.Dispose();
+
+        var contents = fs.File.ReadAllText(log.CurrentLogFilePath!);
+        Assert.That(contents, Does.Contain("verbose detail"));
+    }
+
+    [Test]
     public void Constructor_WhenFileOpenFails_FallsBackToConsoleOnly()
     {
         var env = new MockEnvironmentProvider();

--- a/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedDownloadPatchTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedDownloadPatchTest.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using System.Security.Cryptography;
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class ManifestReleasesFeedDownloadPatchTest
+{
+    private const string DownloadDir = @"C:\downloads";
+
+    private static (ManifestReleasesFeed Feed, Mock<IManifestReleasesFeedProviderService> Provider, MockFileSystem Fs)
+        MakeFeed()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        fs.Directory.CreateDirectory(DownloadDir);
+        var provider = new Mock<IManifestReleasesFeedProviderService>();
+        var log = new Mock<ILogService>();
+        var feedInfo = new FeedInfo { Repository = "KSP2Redux/Redux", Filename = "manifest-beta.json" };
+
+        var feed = new ManifestReleasesFeed(fs, provider.Object, log.Object, DownloadDir, feedInfo);
+        return (feed, provider, fs);
+    }
+
+    private static ReleasePatch MakePatch(byte[] content, string url = "https://example.com/patch.patch")
+    {
+        return new ReleasePatch
+        {
+            Version = "0.2.3.1.1234",
+            Requires = new PatchRequirement { Version = null },
+            Url = url,
+            ChecksumSha256 = Convert.ToHexString(SHA256.HashData(content)),
+            Size = content.Length,
+            ReleasedAt = DateTime.UtcNow,
+        };
+    }
+
+    private static void SetupDownload(Mock<IManifestReleasesFeedProviderService> provider, byte[] content)
+    {
+        provider.Setup(p => p.DownloadPatchAsync(It.IsAny<FeedInfo>(), It.IsAny<ReleasePatch>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                Content = new ByteArrayContent(content) { Headers = { ContentLength = content.Length } },
+                StatusCode = HttpStatusCode.OK,
+            });
+    }
+
+    [Test]
+    public async Task DownloadPatch_ChecksumMatches_ReturnsDownloadedFile()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] content = [1, 2, 3, 4, 5];
+        var patch = MakePatch(content);
+        SetupDownload(provider, content);
+
+        var path = await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None);
+
+        Assert.That(fs.File.Exists(path), Is.True);
+        Assert.That(fs.File.ReadAllBytes(path), Is.EqualTo(content));
+    }
+
+    [Test]
+    public async Task DownloadPatch_ChecksumMismatch_ThrowsAndDeletesCorruptFile()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] content = [1, 2, 3, 4, 5];
+        var patch = MakePatch([9, 9, 9, 9, 9]); // checksum for different bytes than what actually downloads
+        SetupDownload(provider, content);
+
+        Assert.That(async () => await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None),
+            Throws.InvalidOperationException);
+
+        string expectedPath = fs.Path.Combine(DownloadDir, "patch.patch");
+        Assert.That(fs.File.Exists(expectedPath), Is.False);
+    }
+
+    [Test]
+    public async Task DownloadPatch_CachedFileWithWrongHash_RedownloadsInsteadOfTrustingCache()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] goodContent = [1, 2, 3, 4, 5];
+        byte[] staleContent = [9, 9, 9, 9, 9]; // same length as goodContent, but wrong bytes/hash
+        var patch = MakePatch(goodContent);
+
+        string cachedPath = fs.Path.Combine(DownloadDir, "patch.patch");
+        fs.File.WriteAllBytes(cachedPath, staleContent);
+        SetupDownload(provider, goodContent);
+
+        var path = await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None);
+
+        Assert.That(fs.File.ReadAllBytes(path), Is.EqualTo(goodContent));
+        provider.Verify(p => p.DownloadPatchAsync(It.IsAny<FeedInfo>(), It.IsAny<ReleasePatch>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task DownloadPatch_CachedFileMatchesHash_SkipsRedownload()
+    {
+        var (feed, provider, fs) = MakeFeed();
+        byte[] content = [1, 2, 3, 4, 5];
+        var patch = MakePatch(content);
+
+        string cachedPath = fs.Path.Combine(DownloadDir, "patch.patch");
+        fs.File.WriteAllBytes(cachedPath, content);
+        SetupDownload(provider, content);
+
+        var path = await feed.DownloadPatch(patch, _ => { }, (_, _) => { }, CancellationToken.None);
+
+        Assert.That(path, Is.EqualTo(cachedPath));
+        provider.Verify(p => p.DownloadPatchAsync(It.IsAny<FeedInfo>(), It.IsAny<ReleasePatch>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedUpdateManifestTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/ManifestReleasesFeedUpdateManifestTest.cs
@@ -1,0 +1,83 @@
+using Ksp2Redux.Tools.Common;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+using Testably.Abstractions.Testing;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class ManifestReleasesFeedUpdateManifestTest
+{
+    private static (ManifestReleasesFeed Feed, Mock<IManifestReleasesFeedProviderService> Provider)
+        MakeFeed()
+    {
+        var fs = new MockFileSystem(o => o.SimulatingOperatingSystem(SimulationMode.Windows));
+        var provider = new Mock<IManifestReleasesFeedProviderService>();
+        var log = new Mock<ILogService>();
+        var feedInfo = new FeedInfo { Repository = "KSP2Redux/Redux", Filename = "manifest-beta.json" };
+
+        var feed = new ManifestReleasesFeed(fs, provider.Object, log.Object, @"C:\downloads", feedInfo);
+        return (feed, provider);
+    }
+
+    private static ReleaseManifest MakeManifest(string channel, string version) => new()
+    {
+        Channel = channel,
+        GeneratedAt = new DateTime(2026, 1, 1),
+        SchemaVersion = 1,
+        Patches = [new ReleasePatch { Version = version, Requires = new PatchRequirement { Version = null }, Size = 1, Url = "https://x", ChecksumSha256 = "0", ReleasedAt = DateTime.UtcNow }],
+    };
+
+    [Test]
+    public async Task UpdateManifest_SucceedsThenReturnsNull_KeepsThePreviousPatchesAndChannel()
+    {
+        var (feed, provider) = MakeFeed();
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync(MakeManifest("beta", "1.2.3.4.5"));
+        Assert.That(await feed.UpdateManifest(), Is.True);
+
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync((ReleaseManifest?)null);
+        var succeeded = await feed.UpdateManifest();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(succeeded, Is.False, "A failed refresh should still report failure.");
+            Assert.That(feed.CurrentChannel, Is.EqualTo("beta"), "The last known channel must not be wiped out by a failed refresh.");
+            Assert.That(feed.GetAllVersions().Select(v => v.BuildNumber), Is.EqualTo(new[] { "5" }),
+                "A failed refresh must keep showing the last known patch list, not an empty one.");
+        });
+    }
+
+    [Test]
+    public async Task UpdateManifest_SucceedsThenThrows_KeepsThePreviousPatchesAndChannel()
+    {
+        var (feed, provider) = MakeFeed();
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync(MakeManifest("beta", "1.2.3.4.5"));
+        Assert.That(await feed.UpdateManifest(), Is.True);
+
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ThrowsAsync(new HttpRequestException("network unreachable"));
+        var succeeded = await feed.UpdateManifest();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(succeeded, Is.False);
+            Assert.That(feed.CurrentChannel, Is.EqualTo("beta"));
+            Assert.That(feed.GetAllVersions().Select(v => v.BuildNumber), Is.EqualTo(new[] { "5" }));
+        });
+    }
+
+    [Test]
+    public async Task UpdateManifest_NeverSucceededAndFails_FallsBackToAnEmptyInvalidManifest()
+    {
+        var (feed, provider) = MakeFeed();
+        provider.Setup(p => p.GetManifest(It.IsAny<FeedInfo>())).ReturnsAsync((ReleaseManifest?)null);
+
+        var succeeded = await feed.UpdateManifest();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(succeeded, Is.False);
+            Assert.That(feed.CurrentChannel, Is.EqualTo("invalid"));
+            Assert.That(feed.GetAllVersions(), Is.Empty);
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/NewsServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/NewsServiceTest.cs
@@ -1,0 +1,72 @@
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class NewsServiceTest
+{
+    private static (NewsService Service, Mock<INewsProviderService> Provider, Mock<ILogService> Log) MakeService()
+    {
+        var provider = new Mock<INewsProviderService>();
+        var log = new Mock<ILogService>();
+        return (new NewsService(provider.Object, log.Object), provider, log);
+    }
+
+    [Test]
+    public async Task FetchNews_OneItemMissingPublishDate_SkipsItButKeepsTheRest()
+    {
+        var (service, provider, log) = MakeService();
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed
+        {
+            Items =
+            [
+                new FeedItem { Title = "Good post", Link = "https://a", PublishingDate = new DateTime(2026, 1, 1) },
+                new FeedItem { Title = "Missing date", Link = "https://b", PublishingDate = null },
+                new FeedItem { Title = "Another good post", Link = "https://c", PublishingDate = new DateTime(2026, 1, 2) },
+            ],
+        });
+
+        await service.FetchNews();
+        var news = await service.FindAllNews();
+
+        Assert.That(news.Select(n => n.Title), Is.EquivalentTo(new[] { "Good post", "Another good post" }));
+        log.Verify(l => l.Warn(It.Is<string>(s => s.Contains("Missing date")), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetNews_ByStableId_ReturnsTheSameItemAcrossARefetchThatChangesListLength()
+    {
+        var (service, provider, _) = MakeService();
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed
+        {
+            Items =
+            [
+                new FeedItem { Title = "First", Link = "https://a", PublishingDate = new DateTime(2026, 1, 1) },
+                new FeedItem { Title = "Second", Link = "https://b", PublishingDate = new DateTime(2026, 1, 2) },
+            ],
+        });
+        await service.FetchNews();
+        var secondId = (await service.FindAllNews()).Single(n => n.Title == "Second").Id;
+
+        // Simulate the feed being refetched with a different shape - the old index into the list
+        // would now point somewhere else (or be out of range), but the stable id still resolves.
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed
+        {
+            Items = [new FeedItem { Title = "Second", Link = "https://b", PublishingDate = new DateTime(2026, 1, 2) }],
+        });
+        await service.FetchNews();
+
+        Assert.That(service.GetNews(secondId)?.Title, Is.EqualTo("Second"));
+    }
+
+    [Test]
+    public async Task GetNews_IdNoLongerPresent_ReturnsNullInsteadOfThrowing()
+    {
+        var (service, provider, _) = MakeService();
+        provider.Setup(p => p.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        await service.FetchNews();
+
+        Assert.That(service.GetNews("stale-id"), Is.Null);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/UpdateServiceBuildUpdateFoundMessageTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/UpdateServiceBuildUpdateFoundMessageTest.cs
@@ -1,0 +1,41 @@
+using Ksp2Redux.Tools.Launcher.Services;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class UpdateServiceBuildUpdateFoundMessageTest
+{
+    [Test]
+    public void WithReleaseNotes_IncludesThemInTheMessage()
+    {
+        var message = UpdateService.BuildUpdateFoundMessage(new Version(0, 2, 0), "- Fixed the crash on startup\n- Faster updates");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(message, Does.Contain("What's new in v0.2.0:"));
+            Assert.That(message, Does.Contain("Fixed the crash on startup"));
+            Assert.That(message, Does.Contain("download and update"));
+        });
+    }
+
+    [Test]
+    public void NoReleaseNotes_FallsBackToAPlaceholderInsteadOfBlankSpace()
+    {
+        var message = UpdateService.BuildUpdateFoundMessage(new Version(0, 2, 0), null);
+
+        Assert.That(message, Does.Contain("No release notes provided"));
+    }
+
+    [Test]
+    public void VeryLongReleaseNotes_TruncatesInsteadOfShowingAWallOfText()
+    {
+        var longNotes = new string('a', 900);
+
+        var message = UpdateService.BuildUpdateFoundMessage(new Version(0, 2, 0), longNotes);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(message, Does.Contain(new string('a', 500) + "..."));
+            Assert.That(message, Does.Not.Contain(new string('a', 501)));
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/App.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/App.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -23,7 +24,24 @@ public partial class App(IServiceProvider? serviceProvider = null) : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
-        _serviceProvider ??= DefaultServiceProviderProvider.GetDefaultServiceProvider();
+        // Building the DI container touches disk (config load), so it can fail before the logger or
+        // any exception handler exists. Without this, a broken first run just silently vanishes with
+        // nothing to go on - "launcher won't open" bug reports with zero log evidence.
+        try
+        {
+            _serviceProvider ??= DefaultServiceProviderProvider.GetDefaultServiceProvider();
+        }
+        catch (Exception ex)
+        {
+            LogService.WriteEarly($"Fatal startup failure while initializing services: {ex}");
+            ShowFatalStartupError(ex);
+            // IEnvironmentProvider isn't available - the container that would provide it is exactly
+            // what just failed to build.
+#pragma warning disable RS0030
+            Environment.Exit(1);
+#pragma warning restore RS0030
+            return;
+        }
 
         var log = _serviceProvider.GetRequiredService<ILogService>();
         log.Info($"Launcher starting. Log file: {log.CurrentLogFilePath ?? "(console only)"}");
@@ -46,6 +64,28 @@ public partial class App(IServiceProvider? serviceProvider = null) : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    // Deliberately bypasses Avalonia/MsBox.Avalonia entirely - the framework may not be usable yet at
+    // this point, since this only runs when building the DI container (and therefore most of the app's
+    // own services) already failed. A plain native message box has no dependency on any of that.
+    private static void ShowFatalStartupError(Exception ex)
+    {
+        var message = $"KSP2 Redux failed to start:\n\n{ex.Message}\n\n" +
+                      "A bootstrap.log with more detail was written to your logs folder.";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            try
+            {
+                NativeMessageBox.ShowError(message, "KSP2 Redux - Startup Failed");
+                return;
+            }
+            catch (Exception showEx)
+            {
+                LogService.WriteEarly($"Could not show native startup-error dialog: {showEx}");
+            }
+        }
+        Console.Error.WriteLine(message);
     }
 
     private static void HookGlobalExceptionHandlers(ILogService log)

--- a/Ksp2Redux.Tools.Launcher/Colors.axaml
+++ b/Ksp2Redux.Tools.Launcher/Colors.axaml
@@ -26,6 +26,11 @@
     <SolidColorBrush x:Key="DangerBrush" Color="{StaticResource DangerColor}" />
     <SolidColorBrush x:Key="DangerHoverBrush" Color="{StaticResource DangerHoverColor}" />
 
+    <!-- Semantic: non-urgent warnings (e.g. a background feed refresh that fell back to
+         cached data) - deliberately calmer than Danger since nothing is actually broken -->
+    <Color x:Key="WarningColor">#D9A441</Color>
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+
     <!-- Neutral buttons -->
     <Color x:Key="NeutralButtonColor">#666666</Color>
     <Color x:Key="NeutralButtonHoverColor">#333333</Color>

--- a/Ksp2Redux.Tools.Launcher/DefaultServiceProviderProvider.cs
+++ b/Ksp2Redux.Tools.Launcher/DefaultServiceProviderProvider.cs
@@ -42,6 +42,7 @@ public static class DefaultServiceProviderProvider
         serviceCollection.AddSingleton<IKsp2DetectorService, Ksp2DetectorService>();
         serviceCollection.AddSingleton<IMessageBoxService, MessageBoxService>();
         serviceCollection.AddSingleton<IOperatingSystemService, OperatingSystemService>();
+        serviceCollection.AddSingleton<IDiskSpaceService, DiskSpaceService>();
         return serviceCollection.BuildServiceProvider();
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.1.1</Version>
+        <Version>0.2.0</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/Models/GameVersion.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/GameVersion.cs
@@ -16,7 +16,7 @@ public class GameVersion : IEquatable<GameVersion>
     /// <summary>
     /// Read version data VersionID class constants in Assembly-CSharp.dll
     /// </summary>
-    public static GameVersion FromVersionIDType(TypeDefinition versionType, bool IsRedux)
+    public static GameVersion FromVersionIDType(TypeDefinition versionType, bool isRedux)
     {
         string channel = "stable";
         Version version;
@@ -58,7 +58,7 @@ public class GameVersion : IEquatable<GameVersion>
         if (string.IsNullOrWhiteSpace(buildNumber))
             throw new InvalidOperationException($"VERSION_TEXT has an invalid build number: '{versionText}'.");
 
-        if (IsRedux)
+        if (isRedux)
             channel = GetRequiredFieldValueAsString("CHANNEL_NAME");
 
         // try get redux commit hash

--- a/Ksp2Redux.Tools.Launcher/Models/LauncherConfig.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/LauncherConfig.cs
@@ -29,6 +29,11 @@ public class LauncherConfig
 
     public string LauncherRepo { get; set; } = "https://github.com/KSP2Redux/Updater";
 
+    /// <summary>
+    /// When enabled, lowers the log file's minimum level to Debug for more detailed troubleshooting output.
+    /// </summary>
+    public bool VerboseLogging { get; set; } = false;
+
     [JsonIgnore]
     public string StoragePath { get; set; }
 

--- a/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
@@ -35,7 +35,8 @@ public class ManifestReleasesFeed
         _feed = feed;
     }
 
-    public async Task UpdateManifest()
+    /// <returns>false if the fetch failed and the channel was marked invalid, true otherwise.</returns>
+    public async Task<bool> UpdateManifest()
     {
         _log.Info($"Updating manifest for feed {_feed.Repository} / {_feed.Filename}.");
         try
@@ -52,10 +53,11 @@ public class ManifestReleasesFeed
                     GeneratedAt = DateTime.MinValue,
                 };
                 CurrentChannel = "invalid";
-                return;
+                return false;
             }
             CurrentChannel = _manifest.Channel;
             _log.Info($"Manifest loaded for {_feed.Repository} / {_feed.Filename}. Channel={CurrentChannel}, Patches={_manifest.Patches?.Count ?? 0}, GeneratedAt={_manifest.GeneratedAt:O}.");
+            return true;
         }
         catch (Exception e)
         {
@@ -68,6 +70,7 @@ public class ManifestReleasesFeed
                 GeneratedAt = DateTime.MinValue,
             };
             CurrentChannel = "invalid";
+            return false;
         }
     }
 

--- a/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
@@ -35,43 +35,46 @@ public class ManifestReleasesFeed
         _feed = feed;
     }
 
-    /// <returns>false if the fetch failed and the channel was marked invalid, true otherwise.</returns>
+    /// <returns>false if the fetch failed, true otherwise. On failure, a previously-loaded manifest
+    /// (and CurrentChannel) is left untouched rather than replaced, so callers showing a "using the
+    /// last known list" message after a failed refresh are telling the truth. Only falls back to an
+    /// empty "invalid" placeholder if there was never a successful fetch to fall back to.</returns>
     public async Task<bool> UpdateManifest()
     {
         _log.Info($"Updating manifest for feed {_feed.Repository} / {_feed.Filename}.");
         try
         {
-            _manifest = await _manifestReleasesFeedProviderService.GetManifest(_feed);
-            if (_manifest is null)
+            var manifest = await _manifestReleasesFeedProviderService.GetManifest(_feed);
+            if (manifest is null)
             {
-                _log.Warn($"Manifest for {_feed.Repository} / {_feed.Filename} was null. Marking channel as invalid.");
-                _manifest = new ReleaseManifest
-                {
-                    SchemaVersion = 0,
-                    Patches = [],
-                    Channel = "invalid",
-                    GeneratedAt = DateTime.MinValue,
-                };
-                CurrentChannel = "invalid";
+                _log.Warn($"Manifest for {_feed.Repository} / {_feed.Filename} was null. Keeping the last known list, if any.");
+                FallBackToInvalidIfNeverLoaded();
                 return false;
             }
+            _manifest = manifest;
             CurrentChannel = _manifest.Channel;
             _log.Info($"Manifest loaded for {_feed.Repository} / {_feed.Filename}. Channel={CurrentChannel}, Patches={_manifest.Patches?.Count ?? 0}, GeneratedAt={_manifest.GeneratedAt:O}.");
             return true;
         }
         catch (Exception e)
         {
-            _log.Error($"Could not download or parse manifest for {_feed.Repository} / {_feed.Filename}. Marking channel as invalid.", e);
-            _manifest = new ReleaseManifest
-            {
-                SchemaVersion = 0,
-                Patches = [],
-                Channel = "invalid",
-                GeneratedAt = DateTime.MinValue,
-            };
-            CurrentChannel = "invalid";
+            _log.Error($"Could not download or parse manifest for {_feed.Repository} / {_feed.Filename}. Keeping the last known list, if any.", e);
+            FallBackToInvalidIfNeverLoaded();
             return false;
         }
+    }
+
+    private void FallBackToInvalidIfNeverLoaded()
+    {
+        if (_manifest is not null) return;
+        _manifest = new ReleaseManifest
+        {
+            SchemaVersion = 0,
+            Patches = [],
+            Channel = "invalid",
+            GeneratedAt = DateTime.MinValue,
+        };
+        CurrentChannel = "invalid";
     }
 
     public IEnumerable<GameVersion> GetAllVersions()

--- a/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/ManifestReleasesFeed.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Ksp2Redux.Tools.Common;
@@ -170,30 +171,43 @@ public class ManifestReleasesFeed
         log($"Downloading {fileName}");
         reportDownloadProgress(0, patch.Size);
 
-        if (!_fileSystem.File.Exists(patchDownloadTo) || _fileSystem.FileInfo.New(patchDownloadTo).Length != patch.Size)
+        bool cacheIsUsable = _fileSystem.File.Exists(patchDownloadTo) &&
+                              _fileSystem.FileInfo.New(patchDownloadTo).Length == patch.Size &&
+                              await MatchesChecksum(patchDownloadTo, patch, ct);
+
+        if (!cacheIsUsable)
         {
             using var downloadResponse = await _manifestReleasesFeedProviderService.DownloadPatchAsync(_feed, patch, ct);
             long contentLength = downloadResponse.Content.Headers.ContentLength ?? patch.Size;
 
-            using var downloadStream = await downloadResponse.Content.ReadAsStreamAsync(ct);
-            using var fileStream = _fileSystem.FileStream.New(patchDownloadTo, FileMode.Create, FileAccess.Write, FileShare.None,
-                bufferSize: 64 * 1024, useAsync: true);
-
-            var buffer = new byte[64 * 1024];
-            long totalBytesRead = 0;
-            int bytesRead;
-            var updateTimer = Stopwatch.StartNew();
-
-            while ((bytesRead = await downloadStream.ReadAsync(buffer, ct)) > 0)
+            await using (var downloadStream = await downloadResponse.Content.ReadAsStreamAsync(ct))
+            await using (var fileStream = _fileSystem.FileStream.New(patchDownloadTo, FileMode.Create, FileAccess.Write, FileShare.None,
+                             bufferSize: 64 * 1024, useAsync: true))
             {
-                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
-                totalBytesRead += bytesRead;
+                var buffer = new byte[64 * 1024];
+                long totalBytesRead = 0;
+                int bytesRead;
+                var updateTimer = Stopwatch.StartNew();
 
-                if (updateTimer.ElapsedMilliseconds > 100)
+                while ((bytesRead = await downloadStream.ReadAsync(buffer, ct)) > 0)
                 {
-                    reportDownloadProgress(totalBytesRead, contentLength);
-                    updateTimer.Restart();
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
+                    totalBytesRead += bytesRead;
+
+                    if (updateTimer.ElapsedMilliseconds > 100)
+                    {
+                        reportDownloadProgress(totalBytesRead, contentLength);
+                        updateTimer.Restart();
+                    }
                 }
+            }
+
+            if (!await MatchesChecksum(patchDownloadTo, patch, ct))
+            {
+                _log.Error($"Downloaded {fileName} failed checksum verification. Deleting corrupt download.");
+                _fileSystem.File.Delete(patchDownloadTo);
+                throw new InvalidOperationException(
+                    $"Downloaded patch {fileName} did not match its expected checksum. The download may be corrupt or incomplete - please try again.");
             }
         }
         else
@@ -203,5 +217,19 @@ public class ManifestReleasesFeed
 
         log("Download complete.");
         return patchDownloadTo;
+    }
+
+    private async Task<bool> MatchesChecksum(string filePath, ReleasePatch patch, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(patch.ChecksumSha256))
+        {
+            _log.Error($"No checksum available for patch at {patch.Url}, refusing to trust it.");
+            return false;
+        }
+
+        await using var stream = _fileSystem.File.OpenRead(filePath);
+        var hash = await SHA256.HashDataAsync(stream, ct);
+        var actual = Convert.ToHexString(hash);
+        return string.Equals(actual, patch.ChecksumSha256, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Models/News.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/News.cs
@@ -4,6 +4,12 @@ namespace Ksp2Redux.Tools.Launcher.Models;
 
 public sealed record News
 {
+    /// <summary>
+    /// Stable identity for this post - defaults to its link (unique per RSS entry) so a post stays
+    /// addressable across refetches, unlike a list index which shifts when the feed changes shape.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
     public string Title { get; init; } = string.Empty;
     public string Content { get; init; } = string.Empty;
     public DateTime Date { get; init; }

--- a/Ksp2Redux.Tools.Launcher/NativeMessageBox.cs
+++ b/Ksp2Redux.Tools.Launcher/NativeMessageBox.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace Ksp2Redux.Tools.Launcher;
@@ -13,10 +14,10 @@ internal static class NativeMessageBox
     private const uint MB_ICONERROR = 0x10;
 
     [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern int MessageBoxW(nint hWnd, string text, string caption, uint type);
+    private static extern int MessageBoxW(IntPtr hWnd, string text, string caption, uint type);
 
     public static void ShowError(string text, string caption)
     {
-        MessageBoxW(0, text, caption, MB_OK | MB_ICONERROR);
+        MessageBoxW(IntPtr.Zero, text, caption, MB_OK | MB_ICONERROR);
     }
 }

--- a/Ksp2Redux.Tools.Launcher/NativeMessageBox.cs
+++ b/Ksp2Redux.Tools.Launcher/NativeMessageBox.cs
@@ -1,0 +1,22 @@
+using System.Runtime.InteropServices;
+
+namespace Ksp2Redux.Tools.Launcher;
+
+/// <summary>
+/// A plain Win32 message box with zero managed dependencies, for reporting failures so early
+/// (e.g. the DI container itself failing to build) that Avalonia's own dialog stack may not be
+/// safe to use yet.
+/// </summary>
+internal static class NativeMessageBox
+{
+    private const uint MB_OK = 0x0;
+    private const uint MB_ICONERROR = 0x10;
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int MessageBoxW(nint hWnd, string text, string caption, uint type);
+
+    public static void ShowError(string text, string caption)
+    {
+        MessageBoxW(0, text, caption, MB_OK | MB_ICONERROR);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/CacheRestoreException.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/CacheRestoreException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+/// <summary>
+/// Thrown by <see cref="CacheService.RecursivelyRestoreCache"/> when the pre-patch snapshot it needs
+/// to restore from is missing, carrying the directory and expected file so the failure is
+/// distinguishable from other exceptions in a log without inspecting the message text.
+/// </summary>
+public sealed class CacheRestoreException(string directory, string expectedFile)
+    : Exception($"Original stock files were deleted - expected \"{expectedFile}\" under \"{directory}\", uninstallation is impossible.")
+{
+    public string Directory { get; } = directory;
+    public string ExpectedFile { get; } = expectedFile;
+}

--- a/Ksp2Redux.Tools.Launcher/Services/CacheService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/CacheService.cs
@@ -40,15 +40,25 @@ public class CacheService(IFileSystem fileSystem, IZipFileService zipFileService
         }
 
         var tempFile = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), $"uninstall-{Guid.CreateVersion7()}.zip");
-        using (var saveStream = fileSystem.File.Open(tempFile, FileMode.Create, FileAccess.Write))
+        try
         {
-            using (var zipArchive = zipFileService.NewArchive(saveStream, ZipArchiveMode.Create, false))
+            using (var saveStream = fileSystem.File.Open(tempFile, FileMode.Create, FileAccess.Write))
             {
-                AddFolder(zipArchive, directory, "");
-            }   
+                using (var zipArchive = zipFileService.NewArchive(saveStream, ZipArchiveMode.Create, false))
+                {
+                    AddFolder(zipArchive, directory, "");
+                }
+            }
+
+            fileSystem.File.Move(tempFile, fileSystem.Path.Combine(directory, "uninstall.zip"));
         }
-        
-        fileSystem.File.Move(tempFile, fileSystem.Path.Combine(directory, "uninstall.zip"));
+        catch
+        {
+            // A partial snapshot (locked file, full disk) would otherwise sit in the temp folder
+            // forever, silently eating disk space across repeated failed attempts.
+            try { if (fileSystem.File.Exists(tempFile)) fileSystem.File.Delete(tempFile); } catch { }
+            throw;
+        }
     }
 
     public void AddFolder(IZipArchive archive, string directory, string prefix)
@@ -75,7 +85,7 @@ public class CacheService(IFileSystem fileSystem, IZipFileService zipFileService
     {
         if (!fileSystem.File.Exists(fileSystem.Path.Combine(directory, "uninstall.zip")))
         {
-            throw new Exception("Original stock files were deleted, uninstallation is impossible");
+            throw new CacheRestoreException(directory, "uninstall.zip");
         }
 
         if (isForRepatch)

--- a/Ksp2Redux.Tools.Launcher/Services/DiskSpaceService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/DiskSpaceService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+public interface IDiskSpaceService
+{
+    /// <summary>
+    /// Returns the free space available on the drive containing <paramref name="path"/>, in bytes.
+    /// Returns null if the drive could not be determined or queried.
+    /// </summary>
+    long? GetAvailableFreeSpace(string path);
+}
+
+public class DiskSpaceService(IFileSystem fileSystem) : IDiskSpaceService
+{
+    public long? GetAvailableFreeSpace(string path)
+    {
+        var root = fileSystem.Path.GetPathRoot(fileSystem.Path.GetFullPath(path));
+        if (string.IsNullOrEmpty(root)) return null;
+
+        try
+        {
+            return fileSystem.DriveInfo.New(root).AvailableFreeSpace;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/ExternalLinkLauncher.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/ExternalLinkLauncher.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using MsBox.Avalonia.Enums;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+/// <summary>
+/// Shared behavior for opening a link in the default browser from a view model - validates the URL,
+/// awaits the launch, and reports a failure instead of letting a malformed feed link or a missing
+/// default browser throw from a click handler with nothing shown to the user.
+/// </summary>
+internal static class ExternalLinkLauncher
+{
+    public static async Task LaunchAsync(TopLevel? topLevel, string? url, IMessageBoxService messageBoxService, ILogService log)
+    {
+        if (topLevel is null) return;
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            log.Warn($"Ignored invalid link: {url}");
+            await messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Open Link",
+                "That link doesn't look valid.", windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
+
+        try
+        {
+            await topLevel.Launcher.LaunchUriAsync(uri);
+        }
+        catch (Exception ex)
+        {
+            log.Error($"Failed to open link: {url}", ex);
+            await messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Open Link",
+                $"Couldn't open the link: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+        }
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/InstallFailedException.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/InstallFailedException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+/// <summary>
+/// Thrown by <see cref="InstallPlanService.ApplyToFolder"/> when a patch-apply step fails partway
+/// through. <see cref="RolledBack"/> indicates whether the install directory was successfully restored
+/// to its last known-good state (from uninstall.zip) before this was thrown.
+/// </summary>
+public sealed class InstallFailedException(string message, Exception innerException, bool rolledBack)
+    : Exception(message, innerException)
+{
+    public bool RolledBack { get; } = rolledBack;
+}

--- a/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Ksp2Redux.Tools.Common;
@@ -18,11 +19,16 @@ public interface IInstallPlanService
 }
 
 public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheService, IEnvironmentProvider environmentProvider,
-    IAssemblyService assemblyService, IModuleDefinitionService moduleDefinitionService, IZipFileService zipFileService) : IInstallPlanService
+    IAssemblyService assemblyService, IModuleDefinitionService moduleDefinitionService, IZipFileService zipFileService,
+    IDiskSpaceService diskSpaceService) : IInstallPlanService
 {
     private const string EPIC_PREPATCH_NAME = "Ksp2Redux.Tools.Launcher.Prepatches.epic-prepatch.patch";
     private const string STEAM_PREPATCH_NAME = "Ksp2Redux.Tools.Launcher.Prepatches.steam-prepatch.patch";
     private const string PORTABLE_PREPATCH_NAME = "Ksp2Redux.Tools.Launcher.Prepatches.portable-prepatch.patch";
+
+    // Extra headroom on top of the raw estimate below, since patch application briefly holds both the
+    // old and new copy of a changed file, and the download itself needs to sit on disk before it's applied.
+    private const double RequiredSpaceSafetyMargin = 1.2;
     
     public void Describe(InstallPlan installPlan, Action<string> log)
     {
@@ -55,6 +61,8 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
     public async Task ApplyToFolder(InstallPlan installPlan, string install, Action<string> log,
         Action<long, long> downloadProgress, Action<int, int> stepsProgress, CancellationToken ct)
     {
+        EnsureEnoughDiskSpace(installPlan, install, log);
+
         var i = 0;
         foreach (var step in installPlan.Steps)
         {
@@ -137,7 +145,7 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
                     {
                         await patch.AsyncApply(environmentProvider, install, install, log, log);
                     }
-                    
+
                     delete_patch:
                     fileSystem.File.Delete(patchFile);
                     break;
@@ -164,5 +172,53 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
             stepsProgress(++i, installPlan.Steps.Count);
             await Task.Delay(250, ct);
         }
+    }
+
+    private void EnsureEnoughDiskSpace(InstallPlan installPlan, string install, Action<string> log)
+    {
+        long requiredBytes = installPlan.Cost;
+
+        // The first prepatch on an install snapshots the whole directory into uninstall.zip alongside it,
+        // so that needs to fit on the same drive too.
+        bool needsCacheSnapshot = installPlan.Steps.Any(s => s.Action == InstallPlanAction.Prepatch) &&
+                                   !fileSystem.File.Exists(fileSystem.Path.Combine(install, "uninstall.zip"));
+        if (needsCacheSnapshot)
+        {
+            requiredBytes += GetDirectorySize(install);
+        }
+
+        requiredBytes = (long)(requiredBytes * RequiredSpaceSafetyMargin);
+        if (requiredBytes <= 0) return;
+
+        var availableBytes = diskSpaceService.GetAvailableFreeSpace(install);
+        if (availableBytes is null)
+        {
+            log("Could not determine available disk space, skipping pre-flight space check.");
+            return;
+        }
+
+        if (availableBytes < requiredBytes)
+        {
+            throw new InvalidOperationException(
+                $"Not enough free disk space to continue: need approximately {FormatBytes(requiredBytes)}, " +
+                $"but only {FormatBytes(availableBytes.Value)} is available. Free up some space and try again.");
+        }
+    }
+
+    private long GetDirectorySize(string directory)
+    {
+        long total = 0;
+        foreach (var file in fileSystem.Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+        {
+            try { total += fileSystem.FileInfo.New(file).Length; }
+            catch (IOException) { /* file may have been removed/locked concurrently; ignore for this estimate */ }
+        }
+        return total;
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        double mb = bytes / (1024.0 * 1024.0);
+        return mb >= 1024 ? $"{mb / 1024.0:F1} GB" : $"{mb:F0} MB";
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/InstallPlanService.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Ksp2Redux.Tools.Common;
@@ -141,9 +142,14 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
                             throw new ArgumentOutOfRangeException();
                     }
 
-                    using (var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchFile))   // Test: Convert to factory, add interface for patch
+                    try
                     {
+                        using var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchFile);   // Test: Convert to factory, add interface for patch
                         await patch.AsyncApply(environmentProvider, install, install, log, log);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        RollbackOrRethrow(install, log, ex);
                     }
 
                     delete_patch:
@@ -154,9 +160,14 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
                 case InstallPlanAction.ApplyPatchFile:
                 {
                     var patchPath = await step.Argument!(log, downloadProgress, ct);
-                    using (var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchPath))
+                    try
                     {
+                        using var patch = Ksp2Patch.FromFile(fileSystem, zipFileService, patchPath);
                         await patch.AsyncApply(environmentProvider, install, install, log, log);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        RollbackOrRethrow(install, log, ex);
                     }
                     if (step.DeleteAfter && fileSystem.File.Exists(patchPath))
                     {
@@ -172,6 +183,50 @@ public class InstallPlanService(IFileSystem fileSystem, ICacheService cacheServi
             stepsProgress(++i, installPlan.Steps.Count);
             await Task.Delay(250, ct);
         }
+    }
+
+    /// <summary>
+    /// Called when a Prepatch/ApplyPatchFile step throws partway through. If a known-good snapshot
+    /// (uninstall.zip) exists, restores it so a corrupt patch or a mid-write failure (e.g. disk full)
+    /// doesn't leave the install half-patched, then throws <see cref="InstallFailedException"/> describing
+    /// what happened. Note this restores the whole install to the last snapshot, which may discard other
+    /// patches already applied earlier in the same plan - still strictly better than a half-patched install.
+    /// If there is no snapshot to restore (nothing has been written to the install dir yet), rethrows the
+    /// original exception unchanged.
+    /// </summary>
+    private void RollbackOrRethrow(string install, Action<string> log, Exception original)
+    {
+        if (!fileSystem.File.Exists(fileSystem.Path.Combine(install, "uninstall.zip")))
+        {
+            ExceptionDispatchInfo.Capture(original).Throw();
+            return; // unreachable, keeps the compiler happy
+        }
+
+        log($"Install step failed ({original.Message}). Rolling back to the last known-good state...");
+
+        Exception? rollbackFailure = null;
+        try
+        {
+            cacheService.RecursivelyRestoreCache(install, true);
+        }
+        catch (Exception rollbackEx)
+        {
+            rollbackFailure = rollbackEx;
+        }
+
+        if (rollbackFailure is null)
+        {
+            log("Rolled back successfully.");
+            throw new InstallFailedException(
+                $"Installation failed and was automatically rolled back to the previous state. Original error: {original.Message}",
+                original, rolledBack: true);
+        }
+
+        log($"Rollback also failed: {rollbackFailure.Message}");
+        throw new InstallFailedException(
+            $"Installation failed ({original.Message}) and the automatic rollback also failed ({rollbackFailure.Message}). " +
+            "The install may be in a broken state - try Uninstall or Revert to Stock from Settings.",
+            original, rolledBack: false);
     }
 
     private void EnsureEnoughDiskSpace(InstallPlan installPlan, string install, Action<string> log)

--- a/Ksp2Redux.Tools.Launcher/Services/Ksp2DetectorService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/Ksp2DetectorService.cs
@@ -10,7 +10,7 @@ public interface IKsp2DetectorService
     public string? DetectKsp2InstallLocation();
 }
 
-public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, IOperatingSystemService operatingSystemService)
+public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, IOperatingSystemService operatingSystemService, ILogService log)
     : IKsp2DetectorService
 {
     private const string Ksp2SteamAppId = "954850";
@@ -120,18 +120,29 @@ public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider en
         {
             content = fileSystem.File.ReadAllText(libraryFoldersVdf);
         }
-        catch
+        catch (Exception ex)
         {
+            log.Warn($"Found {libraryFoldersVdf} but couldn't read it: {ex.Message}. Additional Steam libraries won't be checked.");
             yield break;
         }
 
+        var matchCount = 0;
         foreach (Match match in LibraryPathRegex.Matches(content))
         {
             var path = match.Groups["path"].Value.Replace(@"\\", @"\");
             if (!string.IsNullOrWhiteSpace(path))
             {
+                matchCount++;
                 yield return path;
             }
+        }
+
+        // A zero-match result here is indistinguishable from "just no extra libraries configured" to
+        // the user - but it can also mean Steam had this file mid-write when we read it, which would
+        // otherwise look identical to "KSP2 isn't installed" once detection comes up empty.
+        if (matchCount == 0)
+        {
+            log.Warn($"{libraryFoldersVdf} exists but no library paths were parsed out of it. If KSP2 isn't detected, this file may have been read mid-write.");
         }
     }
 
@@ -142,13 +153,19 @@ public class Ksp2DetectorService(IFileSystem fileSystem, IEnvironmentProvider en
         {
             content = fileSystem.File.ReadAllText(manifestPath);
         }
-        catch
+        catch (Exception ex)
         {
+            log.Warn($"Found {manifestPath} but couldn't read it: {ex.Message}.");
             return null;
         }
 
         var match = InstallDirRegex.Match(content);
-        return match.Success ? match.Groups["installdir"].Value : null;
+        if (!match.Success)
+        {
+            log.Warn($"{manifestPath} exists but its installdir couldn't be parsed out of it. If KSP2 isn't detected, this file may have been read mid-write.");
+            return null;
+        }
+        return match.Groups["installdir"].Value;
     }
 
     private static readonly Regex LibraryPathRegex = new(

--- a/Ksp2Redux.Tools.Launcher/Services/Ksp2InstallService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/Ksp2InstallService.cs
@@ -36,9 +36,9 @@ public interface IKsp2InstallService
     void ApplyActiveInstallBootConfig();
 }
 
-public class Ksp2InstallService(ILauncherConfigService launcherConfigService, IFileSystem fileSystem, IModuleDefinitionService moduleDefinitionService) : IKsp2InstallService
+public class Ksp2InstallService(ILauncherConfigService launcherConfigService, IFileSystem fileSystem, IModuleDefinitionService moduleDefinitionService, ILogService logService) : IKsp2InstallService
 {
-    private readonly HashSet<Guid> _checkedThisSession = new();
+    private readonly HashSet<Guid> _checkedThisSession = [];
 
     public Ksp2Install? Ksp2 { get; private set; }
 
@@ -249,7 +249,13 @@ public class Ksp2InstallService(ILauncherConfigService launcherConfigService, IF
             }
             fileSystem.File.WriteAllLines(bootConfigPath, lines);
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException ex)
+        {
+            logService.Warn($"Failed to write {bootConfigPath}: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logService.Warn($"Failed to write {bootConfigPath}: {ex.Message}");
+        }
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LauncherConfigService.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.IO.Abstractions;
 using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Threading;
 using Ksp2Redux.Tools.Launcher.Models;
+using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
 
@@ -16,17 +19,21 @@ public class LauncherConfigService : ILauncherConfigService
 {
     private readonly IFileSystem _fileSystem;
     private readonly IEnvironmentProvider _environmentProvider;
+    private readonly IMessageBoxService _messageBoxService;
     private readonly ILogService _log;
+    private bool _showingSaveFailureDialog;
 
     public LauncherConfig Config { get; set; }
     private readonly JsonSerializerOptions StorageOptions = new() { WriteIndented = true };
 
     private const string LauncherConfigJson = "redux-launcher-config.json";
 
-    public LauncherConfigService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, ILogService log)
+    public LauncherConfigService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider,
+        IMessageBoxService messageBoxService, ILogService log)
     {
         _fileSystem = fileSystem;
         _environmentProvider = environmentProvider;
+        _messageBoxService = messageBoxService;
         _log = log;
         GetOrCreateCurrentConfig(_fileSystem);
     }
@@ -117,22 +124,54 @@ public class LauncherConfigService : ILauncherConfigService
         return string.IsNullOrEmpty(leaf) ? "KSP2" : leaf;
     }
     
+    // Called directly from dozens of UI property-changed callbacks (renaming an install, toggling a
+    // checkbox, etc.) via Ksp2InstallService, so a transient I/O failure here (AppData briefly
+    // unreachable - a OneDrive redirect, a USB drive, a network share) must never throw back into a
+    // data-binding callback and crash the whole app. Report and swallow instead.
     public void Save()
     {
-        var directory = _fileSystem.Path.GetDirectoryName(Config.StoragePath);
-        if (string.IsNullOrWhiteSpace(directory))
-            throw new InvalidOperationException($"Could not determine config directory from storage path '{Config.StoragePath}'.");
-
-        _fileSystem.Directory.CreateDirectory(directory);
         try
         {
+            var directory = _fileSystem.Path.GetDirectoryName(Config.StoragePath);
+            if (string.IsNullOrWhiteSpace(directory))
+                throw new InvalidOperationException($"Could not determine config directory from storage path '{Config.StoragePath}'.");
+
+            _fileSystem.Directory.CreateDirectory(directory);
             _fileSystem.File.WriteAllText(Config.StoragePath, JsonSerializer.Serialize(Config, StorageOptions));
             _log.Info($"Launcher config saved to {Config.StoragePath}");
         }
         catch (Exception ex)
         {
             _log.Error($"Failed to save launcher config to {Config.StoragePath}", ex);
-            throw;
+            ReportSaveFailure(ex);
+        }
+    }
+
+    private void ReportSaveFailure(Exception ex)
+    {
+        if (_showingSaveFailureDialog) return;
+        _showingSaveFailureDialog = true;
+        try
+        {
+            Dispatcher.UIThread.Post(async () =>
+            {
+                try
+                {
+                    await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Save Settings",
+                        $"Your changes could not be saved: {ex.Message}\nThey may be lost if you close the launcher. " +
+                        $"Check that {Config.StoragePath} is writable and try again.",
+                        ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+                }
+                finally
+                {
+                    _showingSaveFailureDialog = false;
+                }
+            });
+        }
+        catch (Exception dispatchEx)
+        {
+            _log.Error("Could not show save-failure dialog.", dispatchEx);
+            _showingSaveFailureDialog = false;
         }
     }
 

--- a/Ksp2Redux.Tools.Launcher/Services/LogService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LogService.cs
@@ -8,6 +8,14 @@ using System.Text;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
 
+public enum LogLevel
+{
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+}
+
 public interface ILogService
 {
     void Info(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "");
@@ -15,25 +23,36 @@ public interface ILogService
     void Error(string message, Exception? exception = null, [CallerFilePath] string source = "", [CallerMemberName] string member = "");
     void Debug(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "");
     string? CurrentLogFilePath { get; }
+
+    /// <summary>
+    /// The lowest level that will actually be written. Defaults to <see cref="Services.LogLevel.Info"/>;
+    /// lower it to <see cref="Services.LogLevel.Debug"/> for troubleshooting a specific session.
+    /// </summary>
+    LogLevel MinimumLevel { get; set; }
 }
 
 public sealed class LogService : ILogService, IDisposable
 {
     private const int MaxLogFilesToKeep = 10;
+    private const long DefaultMaxLogFileSizeBytes = 20 * 1024 * 1024;
     private const string LogFilePrefix = "launcher-";
     private const string LogFileExtension = ".log";
 
     private readonly IFileSystem _fileSystem;
+    private readonly long _maxLogFileSizeBytes;
     private readonly object _writeLock = new();
     private StreamWriter? _writer;
     private bool _disposed;
+    private bool _sizeCapReached;
     private readonly int _processId;
 
     public string? CurrentLogFilePath { get; private set; }
+    public LogLevel MinimumLevel { get; set; } = LogLevel.Info;
 
-    public LogService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider)
+    public LogService(IFileSystem fileSystem, IEnvironmentProvider environmentProvider, long maxLogFileSizeBytes = DefaultMaxLogFileSizeBytes)
     {
         _fileSystem = fileSystem;
+        _maxLogFileSizeBytes = maxLogFileSizeBytes;
         _processId = environmentProvider.ProcessId;
         try
         {
@@ -96,28 +115,28 @@ public sealed class LogService : ILogService, IDisposable
     }
 
     public void Info(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("INFO", message, null, source, member);
+        => Write(LogLevel.Info, "INFO", message, null, source, member);
 
     public void Warn(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("WARN", message, null, source, member);
+        => Write(LogLevel.Warn, "WARN", message, null, source, member);
 
     public void Error(string message, Exception? exception = null, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("ERROR", message, exception, source, member);
+        => Write(LogLevel.Error, "ERROR", message, exception, source, member);
 
     public void Debug(string message, [CallerFilePath] string source = "", [CallerMemberName] string member = "")
-        => Write("DEBUG", message, null, source, member);
+        => Write(LogLevel.Debug, "DEBUG", message, null, source, member);
 
-    private void Write(string level, string message, Exception? exception, string source, string member)
+    private void Write(LogLevel level, string levelName, string message, Exception? exception, string source, string member)
     {
-        if (_disposed) return;
+        if (_disposed || level < MinimumLevel) return;
 
         var sourceName = string.IsNullOrEmpty(source)
             ? ""
             : _fileSystem.Path.GetFileNameWithoutExtension(source);
 
         var prefix = string.IsNullOrEmpty(sourceName)
-            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{level}]"
-            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{level}] [{sourceName}.{member}]";
+            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}]"
+            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}] [{sourceName}.{member}]";
 
         var line = $"{prefix} {message}";
 
@@ -125,8 +144,17 @@ public sealed class LogService : ILogService, IDisposable
         {
             try
             {
-                _writer?.WriteLine(line);
-                if (exception != null) _writer?.WriteLine(exception.ToString());
+                if (!_sizeCapReached && CurrentLogFilePath is not null &&
+                    _fileSystem.FileInfo.New(CurrentLogFilePath).Length >= _maxLogFileSizeBytes)
+                {
+                    _sizeCapReached = true;
+                    _writer?.WriteLine($"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [WARN] Log file reached {_maxLogFileSizeBytes} bytes, no further lines will be written to disk this session.");
+                }
+                if (!_sizeCapReached)
+                {
+                    _writer?.WriteLine(line);
+                    if (exception != null) _writer?.WriteLine(exception.ToString());
+                }
             }
             catch { }
         }
@@ -146,9 +174,12 @@ public sealed class LogService : ILogService, IDisposable
         }
     }
 
+    private const long MaxBootstrapLogSizeBytes = 1 * 1024 * 1024;
+
     /// <summary>
     /// Best-effort log used before the DI container is available (Program.cs update-stage error handling).
-    /// Appends to a bootstrap log file in the same logs directory the regular LogService writes to.
+    /// Appends to a bootstrap log file shared across every launch, so entries are tagged with the process id
+    /// to tell separate sessions apart, and the file is reset once it grows past a small cap.
     /// </summary>
     public static void WriteEarly(string message)
     {
@@ -159,7 +190,11 @@ public sealed class LogService : ILogService, IDisposable
             var logsDir = Path.Combine(appdata, LocalStoragePaths.ReduxFolder, LocalStoragePaths.LogsSubfolder);
             Directory.CreateDirectory(logsDir);
             var path = Path.Combine(logsDir, "bootstrap.log");
-            var line = $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [EARLY] {message}{Environment.NewLine}";
+            if (File.Exists(path) && new FileInfo(path).Length >= MaxBootstrapLogSizeBytes)
+            {
+                File.Delete(path);
+            }
+            var line = $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [EARLY] [pid={Environment.ProcessId}] {message}{Environment.NewLine}";
             File.AppendAllText(path, line);
             Console.WriteLine(line.TrimEnd());
         }

--- a/Ksp2Redux.Tools.Launcher/Services/LogService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/LogService.cs
@@ -134,9 +134,11 @@ public sealed class LogService : ILogService, IDisposable
             ? ""
             : _fileSystem.Path.GetFileNameWithoutExtension(source);
 
+        // Tag every line with the process id so a fragment pasted out of a bug report can still be
+        // matched back to which run (and which header, further up the file) it came from.
         var prefix = string.IsNullOrEmpty(sourceName)
-            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}]"
-            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [{levelName}] [{sourceName}.{member}]";
+            ? $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [pid={_processId}] [{levelName}]"
+            : $"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [pid={_processId}] [{levelName}] [{sourceName}.{member}]";
 
         var line = $"{prefix} {message}";
 
@@ -148,7 +150,7 @@ public sealed class LogService : ILogService, IDisposable
                     _fileSystem.FileInfo.New(CurrentLogFilePath).Length >= _maxLogFileSizeBytes)
                 {
                     _sizeCapReached = true;
-                    _writer?.WriteLine($"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [WARN] Log file reached {_maxLogFileSizeBytes} bytes, no further lines will be written to disk this session.");
+                    _writer?.WriteLine($"[{DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff}] [pid={_processId}] [WARN] Log file reached {_maxLogFileSizeBytes} bytes, no further lines will be written to disk this session.");
                 }
                 if (!_sizeCapReached)
                 {

--- a/Ksp2Redux.Tools.Launcher/Services/ManifestReleasesFeedProviderService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/ManifestReleasesFeedProviderService.cs
@@ -20,7 +20,9 @@ public interface IManifestReleasesFeedProviderService
 public class ManifestReleasesFeedProviderService(IAssemblyService assemblyService, ILogService log) : IManifestReleasesFeedProviderService
 {
     private readonly Dictionary<FeedInfo, GitHubClient> _clients = new();
-    private readonly HttpClient _downloadClient = new();
+    // ResponseHeadersRead means this only bounds getting the response headers for a patch download,
+    // not the body copy that follows - safe to keep short even for large patch files.
+    private readonly HttpClient _downloadClient = new() { Timeout = TimeSpan.FromSeconds(30) };
 
     private GitHubClient GetOrCreateClient(FeedInfo feed)
     {

--- a/Ksp2Redux.Tools.Launcher/Services/NewsProviderService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/NewsProviderService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using CodeHollow.FeedReader;
 
 namespace Ksp2Redux.Tools.Launcher.Services;
@@ -15,10 +17,20 @@ public class NewsProviderService : INewsProviderService
     // private string _tomlTargetUrl => _rawRepoTargetUrl + _tomlTargetFile;
     // private string _imageTargetUrl => _rawRepoTargetUrl + "images/";
 
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(15);
     private const string RssFeed = "https://ksp2redux.org/blog/rss.xml";
+
     public async Task<Feed> GetSyndicationFeed()
     {
-        var items = await FeedReader.ReadAsync(RssFeed);
-        return items ?? new Feed();
+        using var cts = new CancellationTokenSource(RequestTimeout);
+        try
+        {
+            var items = await FeedReader.ReadAsync(RssFeed, cts.Token);
+            return items ?? new Feed();
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Timed out after {RequestTimeout.TotalSeconds:0}s fetching the news feed from {RssFeed}.");
+        }
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/NewsService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/NewsService.cs
@@ -10,20 +10,17 @@ namespace Ksp2Redux.Tools.Launcher.Services;
 public interface INewsService
 {
     Task<List<News>> FindAllNews();
-    News GetNews(int id);
-    int GetNewsId(News? news);
+    News? GetNews(string? id);
     Task FetchNews();
 }
 
-public class NewsService(INewsProviderService newsProviderService) : INewsService
+public class NewsService(INewsProviderService newsProviderService, ILogService log) : INewsService
 {
     private List<News> _newsList = new();
-    
+
     public async Task<List<News>> FindAllNews() => await Task.Run(() => _newsList.OrderByDescending(n => n.Date).ToList());
 
-    public News GetNews(int id) => id == -1 ? new News() : _newsList[id];
-    
-    public int GetNewsId(News? news) => news == null ? -1 : _newsList.IndexOf(news);
+    public News? GetNews(string? id) => id is null ? null : _newsList.FirstOrDefault(n => n.Id == id);
 
     public async Task FetchNews()
     {
@@ -35,14 +32,25 @@ public class NewsService(INewsProviderService newsProviderService) : INewsServic
 
     private void LoadNewsFromFeed(Feed rssNewsContent)
     {
-        _newsList = rssNewsContent.Items.Select(item => new News
+        var newsList = new List<News>();
+        foreach (var item in rssNewsContent.Items)
+        {
+            if (item.PublishingDate is not { } date)
             {
+                log.Warn($"Skipping RSS item \"{item.Title}\" - missing or unparseable publish date.");
+                continue;
+            }
+
+            newsList.Add(new News
+            {
+                Id = string.IsNullOrWhiteSpace(item.Link) ? Guid.NewGuid().ToString() : item.Link,
                 Title = item.Title,
                 Author = item.Author,
                 Content = item.Content,
                 Link = item.Link,
-                Date = (DateTime)item.PublishingDate!
-            }
-        ).OrderBy(n => n.Date).ToList();
+                Date = date,
+            });
+        }
+        _newsList = newsList.OrderBy(n => n.Date).ToList();
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -60,7 +60,7 @@ public class UpdateService : IUpdateService
 
     public UpdateService(ILauncherConfigService launcherConfigService, IFileSystem fileSystem, IEnvironmentProvider environmentProvider, IAssemblyService assemblyService, IMessageBoxService messageBoxService, ILogService log)
     {
-        _http = new HttpClient();
+        _http = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
         _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(
             new ProductHeaderValue("Ksp2Redux.Tools.Launcher", assemblyService.GetName().Version?.ToString() ?? "0.0.0")));
         _fileSystem = fileSystem;
@@ -210,7 +210,12 @@ public class UpdateService : IUpdateService
 
                     if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        await Process.Start("chmod", $"+x \"{updatePath}\"").WaitForExitAsync();
+                        using var chmod = Process.Start("chmod", $"+x \"{updatePath}\"")!;
+                        await chmod.WaitForExitAsync();
+                        if (chmod.ExitCode != 0)
+                        {
+                            throw new InvalidOperationException($"chmod +x on {updatePath} exited with code {chmod.ExitCode}.");
+                        }
                     }
 
                     TriggerRestart(updatePath);

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -56,6 +56,28 @@ public class UpdateService : IUpdateService
         [JsonPropertyName("tag_name")] public string TagName { get; set; } = "";
         [JsonPropertyName("prerelease")] public bool Prerelease { get; set; }
         [JsonPropertyName("assets")] public GitHubReleaseAsset[] Assets { get; set; } = [];
+        [JsonPropertyName("body")] public string? Body { get; set; }
+    }
+
+    // Release notes are commonly edited on GitHub after the build was already tagged and uploaded,
+    // so this is built fresh from whatever the release currently says rather than anything baked in
+    // at build time. Pure and dependency-free so it's unit-testable without standing up the whole service.
+    public static string BuildUpdateFoundMessage(Version newVersion, string? releaseNotes)
+    {
+        const string actionMessage = "The launcher will download and update, it may restart a few times during this.\nWithout updating you cannot install new Redux versions.";
+        const int maxNotesLength = 500;
+
+        if (string.IsNullOrWhiteSpace(releaseNotes))
+        {
+            return $"What's new in v{newVersion}:\n(No release notes provided.)\n\n{actionMessage}";
+        }
+
+        var trimmed = releaseNotes.Trim();
+        var shown = trimmed.Length > maxNotesLength
+            ? trimmed[..maxNotesLength].TrimEnd() + "..."
+            : trimmed;
+
+        return $"What's new in v{newVersion}:\n{shown}\n\n{actionMessage}";
     }
 
     public UpdateService(ILauncherConfigService launcherConfigService, IFileSystem fileSystem, IEnvironmentProvider environmentProvider, IAssemblyService assemblyService, IMessageBoxService messageBoxService, ILogService log)
@@ -155,7 +177,7 @@ public class UpdateService : IUpdateService
             }
 
             var result = await _messageBoxService.ShowMessageBoxAsOwnedAsync("Update Found",
-                "The launcher will download and update, it may restart a few times during this.\nWithout updating you cannot install new Redux versions.", ButtonEnum.OkCancel,
+                BuildUpdateFoundMessage(latestRelease.Version, latestRelease.Release.Body), ButtonEnum.OkCancel,
                 windowStartupLocation: WindowStartupLocation.CenterOwner);
 
             if (result != ButtonResult.Ok) return false;

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Community/CommunityTabViewModel.cs
@@ -1,12 +1,17 @@
-﻿using CommunityToolkit.Mvvm.Input;
+﻿using System.Threading.Tasks;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.Input;
 using Ksp2Redux.Tools.Launcher.Services;
 using Ksp2Redux.Tools.Launcher.ViewModels.Shared;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Community;
 
-public partial class CommunityTabViewModel(INewsService newsService) : ViewModelBase
+public partial class CommunityTabViewModel(INewsService newsService, IMessageBoxService messageBoxService, ILogService log) : ViewModelBase
 {
-    private int SelectedNewsId
+    public Task LaunchExternalLinkAsync(TopLevel? topLevel, string? url)
+        => ExternalLinkLauncher.LaunchAsync(topLevel, url, messageBoxService, log);
+
+    private string? SelectedNewsId
     {
         get;
         set
@@ -19,13 +24,15 @@ public partial class CommunityTabViewModel(INewsService newsService) : ViewModel
                 OnPropertyChanged(nameof(NewsVisible));
             }
         }
-    } = -1;
+    }
 
-    public NewsItemViewModel SelectedNews => new(newsService, newsService.GetNews(SelectedNewsId));
-    
-    public bool NewsVisible => SelectedNewsId != -1;
-    
-    public void SetSelectedNewsId(int newsId)
+    // Falls back to an empty News record if the selected post no longer exists (e.g. the feed was
+    // refetched and dropped it) instead of throwing or showing stale content.
+    public NewsItemViewModel SelectedNews => new(newsService.GetNews(SelectedNewsId) ?? new());
+
+    public bool NewsVisible => SelectedNewsId is not null;
+
+    public void SetSelectedNewsId(string? newsId)
     {
         SelectedNewsId = newsId;
     }
@@ -33,6 +40,6 @@ public partial class CommunityTabViewModel(INewsService newsService) : ViewModel
     [RelayCommand]
     private void DeselectNews()
     {
-        SelectedNewsId = -1;
+        SelectedNewsId = null;
     }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -55,8 +55,12 @@ public partial class HomeTabViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool MainButtonEnabled { get; set; }
 
+    // Null/empty means "no tooltip" - the enabled states below intentionally clear this, since
+    // a tooltip that just repeats the button's own label (e.g. "Install Ksp2Redux" on an already
+    // labeled INSTALL button) is redundant clutter. It's only worth showing when it explains why
+    // the button is disabled, which the label alone can't do.
     [ObservableProperty]
-    public partial string MainButtonTooltip { get; set; } = "Loading...";
+    public partial string? MainButtonTooltip { get; set; } = "Loading...";
 
     [ObservableProperty]
     public partial bool IsProgressVisible { get; set; }
@@ -297,13 +301,15 @@ public partial class HomeTabViewModel : ViewModelBase
         var linuxLaunchBlocked = _operatingSystemService.IsLinux() && !(_ksp2InstallService.ActiveEntry?.LaunchThroughSteam ?? false);
         const string linuxLaunchBlockedTooltip = "Enable \"Launch through Steam\" in settings to launch on Linux.";
 
+        const string installationDisabledTooltip = "The launcher needs to update itself before you can install or update Redux.";
+
         if (ksp2.Distribution != Distribution.Redux)
         {
             MainButtonEnabled = true;
+            MainButtonTooltip = null;
             if (selectedVersion.Version.Equals(ksp2.GameVersion) || selectedVersion.Channel == "installed")
             {
                 MainButtonShown = MainButtonState.Launch;
-                MainButtonTooltip = "Launch Stock KSP2";
                 if (linuxLaunchBlocked)
                 {
                     MainButtonEnabled = false;
@@ -314,7 +320,7 @@ public partial class HomeTabViewModel : ViewModelBase
             {
                 MainButtonEnabled = !InstallationDisabled;
                 MainButtonShown = MainButtonState.Install;
-                MainButtonTooltip = "Install Ksp2Redux";
+                if (InstallationDisabled) MainButtonTooltip = installationDisabledTooltip;
             }
             return;
         }
@@ -323,7 +329,7 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             MainButtonEnabled = true;
             MainButtonShown = MainButtonState.Launch;
-            MainButtonTooltip = "Launch Ksp2Redux";
+            MainButtonTooltip = null;
             if (linuxLaunchBlocked)
             {
                 MainButtonEnabled = false;
@@ -334,7 +340,7 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             MainButtonEnabled = !InstallationDisabled;
             MainButtonShown = MainButtonState.Update;
-            MainButtonTooltip = "Update Ksp2Redux";
+            MainButtonTooltip = InstallationDisabled ? installationDisabledTooltip : null;
         }
     }
 
@@ -410,7 +416,7 @@ public partial class HomeTabViewModel : ViewModelBase
         // Set up process cancellation trigger.
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
-        MainButtonTooltip = "Cancel installation";
+        MainButtonTooltip = null;
         _cancelCurrentOperation = new CancellationTokenSource();
 
         Log("Creating install plan");
@@ -471,7 +477,7 @@ public partial class HomeTabViewModel : ViewModelBase
         
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
-        MainButtonTooltip = "Cancel installation";
+        MainButtonTooltip = null;
         _cancelCurrentOperation = new CancellationTokenSource();
         
         try

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -6,11 +6,13 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
+using MsBox.Avalonia.Enums;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Home;
 
@@ -22,6 +24,7 @@ public partial class HomeTabViewModel : ViewModelBase
     private readonly IInstallPlanService _installPlanService;
     private readonly IUpdateService _updateService;
     private readonly IOperatingSystemService _operatingSystemService;
+    private readonly IMessageBoxService _messageBoxService;
     private readonly ILogService _log;
     
     public ObservableCollection<GameVersionViewModel> Versions { get; } = [];
@@ -88,7 +91,7 @@ public partial class HomeTabViewModel : ViewModelBase
         item => (item as GameVersionViewModel)?.Channel ?? string.Empty;
 
     public HomeTabViewModel(IKsp2InstallService ksp2InstallService,
-        ILauncherConfigService launcherConfigService, IReleasesFeedService releasesFeedService, IInstallPlanService installPlanService, IUpdateService updateService, IOperatingSystemService operatingSystemService, ILogService log)
+        ILauncherConfigService launcherConfigService, IReleasesFeedService releasesFeedService, IInstallPlanService installPlanService, IUpdateService updateService, IOperatingSystemService operatingSystemService, IMessageBoxService messageBoxService, ILogService log)
     {
         _ksp2InstallService = ksp2InstallService;
         _launcherConfigService = launcherConfigService;
@@ -96,6 +99,7 @@ public partial class HomeTabViewModel : ViewModelBase
         _installPlanService = installPlanService;
         _updateService = updateService;
         _operatingSystemService = operatingSystemService;
+        _messageBoxService = messageBoxService;
         _log = log;
 
         RebuildInstallsCollection();
@@ -589,6 +593,9 @@ public partial class HomeTabViewModel : ViewModelBase
         catch (Exception ex)
         {
             _log.Error("Manual launcher update failed.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Update Failed!",
+                $"Something went wrong while checking for launcher updates: {ex.Message}\nPlease try again later.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
         }
     }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -380,6 +380,10 @@ public partial class HomeTabViewModel : ViewModelBase
             await RunPlanOnInstall(plan, ksp2);
             Log("KSP2 Redux Successfully Installed");
         }
+        catch (OperationCanceledException)
+        {
+            Log("Installation cancelled");
+        }
         catch (Exception e)
         {
             Log($"Error updating Redux: {e.Message}");
@@ -428,6 +432,10 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             await RunPlanOnInstall(plan, ksp2);
             Log("KSP2 Redux Successfully Installed");
+        }
+        catch (OperationCanceledException)
+        {
+            Log("Installation cancelled");
         }
         catch (Exception e)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -27,9 +27,17 @@ public partial class HomeTabViewModel : ViewModelBase
     public ObservableCollection<GameVersionViewModel> Versions { get; } = [];
     public ObservableCollection<Ksp2InstallChoiceViewModel> Installs { get; } = [];
 
-    [ObservableProperty] private GameVersionViewModel? _selectedVersion;
-    [ObservableProperty] private Ksp2InstallChoiceViewModel? _selectedInstall;
-    [ObservableProperty] private bool _isInstallSwitcherEnabled;
+    [ObservableProperty]
+    public partial GameVersionViewModel? SelectedVersion { get; set; }
+
+    [ObservableProperty]
+    public partial Ksp2InstallChoiceViewModel? SelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsInstallSwitcherEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial bool FeedRefreshFailed { get; set; }
 
     public enum MainButtonState
     {
@@ -38,18 +46,39 @@ public partial class HomeTabViewModel : ViewModelBase
         Update,
         Cancel,
     }
-    [ObservableProperty] private MainButtonState _mainButtonShown;
-    [ObservableProperty] private bool _mainButtonEnabled;
-    [ObservableProperty] private string _mainButtonTooltip = "Loading...";
-    [ObservableProperty] private bool _isProgressVisible;
-    [ObservableProperty] private float _downloadProgressMb = 250;
-    [ObservableProperty] private float _downloadProgressTotalMb = 450;
-    [ObservableProperty] private float _installProgressSteps = 1;
-    [ObservableProperty] private float _installProgressTotalSteps = 3;
-    [ObservableProperty] private bool _isInstallLogVisible;
-    [ObservableProperty] private string _installLogText = string.Empty;
-    [ObservableProperty] private bool _installationDisabled;
-    
+    [ObservableProperty]
+    public partial MainButtonState MainButtonShown { get; set; }
+
+    [ObservableProperty]
+    public partial bool MainButtonEnabled { get; set; }
+
+    [ObservableProperty]
+    public partial string MainButtonTooltip { get; set; } = "Loading...";
+
+    [ObservableProperty]
+    public partial bool IsProgressVisible { get; set; }
+
+    [ObservableProperty]
+    public partial float DownloadProgressMb { get; set; } = 250;
+
+    [ObservableProperty]
+    public partial float DownloadProgressTotalMb { get; set; } = 450;
+
+    [ObservableProperty]
+    public partial float InstallProgressSteps { get; set; } = 1;
+
+    [ObservableProperty]
+    public partial float InstallProgressTotalSteps { get; set; } = 3;
+
+    [ObservableProperty]
+    public partial bool IsInstallLogVisible { get; set; }
+
+    [ObservableProperty]
+    public partial string InstallLogText { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial bool InstallationDisabled { get; set; }
+
     private readonly StringBuilder _installLogBuilder = new();
     private readonly Lock _installLogLock = new();
     private bool _installLogUpdateQueued;
@@ -130,10 +159,12 @@ public partial class HomeTabViewModel : ViewModelBase
     }
     private async Task UpdateAsync()
     {
+        var allSucceeded = true;
         foreach (var feed in _releasesFeedService.ReleasesFeed)
         {
-            await feed.Value.UpdateManifest();
+            if (!await feed.Value.UpdateManifest()) allSucceeded = false;
         }
+        FeedRefreshFailed = !allSucceeded;
     }
 
     // Single refresh entry point shared by the periodic timer and, later, a manual button / F5.

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -230,22 +230,45 @@ public partial class HomeTabViewModel : ViewModelBase
                 FileName = $"steam://rungameid/{appId}",
                 UseShellExecute = true,
             };
-            Process.Start(startInfo);
+            try
+            {
+                Process.Start(startInfo);
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Failed to launch through Steam.", ex);
+                await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Launch",
+                    $"Couldn't open Steam: {ex.Message}\nMake sure Steam is installed and try again.",
+                    ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+            }
             return;
         }
 
         MainButtonEnabled = false;
-        using Process process = new();
-        process.StartInfo.FileName = _ksp2InstallService.Ksp2.ExePath;
-        process.StartInfo.WorkingDirectory = _ksp2InstallService.Ksp2.InstallDir;
-        var launchArgs = activeEntry.LaunchArguments;
-        if (!string.IsNullOrWhiteSpace(launchArgs))
+        try
         {
-            process.StartInfo.Arguments = launchArgs;
+            using Process process = new();
+            process.StartInfo.FileName = _ksp2InstallService.Ksp2.ExePath;
+            process.StartInfo.WorkingDirectory = _ksp2InstallService.Ksp2.InstallDir;
+            var launchArgs = activeEntry.LaunchArguments;
+            if (!string.IsNullOrWhiteSpace(launchArgs))
+            {
+                process.StartInfo.Arguments = launchArgs;
+            }
+            process.Start();
+            await process.WaitForExitAsync();
         }
-        process.Start();
-        await process.WaitForExitAsync();
-        MainButtonEnabled = true;
+        catch (Exception ex)
+        {
+            _log.Error("Failed to launch KSP2.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Launch",
+                $"Couldn't start the game: {ex.Message}\nIt may have been moved, removed, or blocked by antivirus software.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+        }
+        finally
+        {
+            MainButtonEnabled = true;
+        }
     }
 
     [RelayCommand]

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -451,12 +451,11 @@ public partial class HomeTabViewModel : ViewModelBase
         }
         catch (InstallFailedException e)
         {
-            Log(e.Message);
+            LogError(e.Message, e);
         }
         catch (Exception e)
         {
-            Log($"Error updating Redux: {e.Message}");
-            Log($"Stack Trace: {e.StackTrace}");
+            LogError($"Error updating Redux: {e.Message}", e);
             Log($"Redux may be in an invalid state, try uninstalling and reinstalling");
         }
         finally
@@ -508,12 +507,11 @@ public partial class HomeTabViewModel : ViewModelBase
         }
         catch (InstallFailedException e)
         {
-            Log(e.Message);
+            LogError(e.Message, e);
         }
         catch (Exception e)
         {
-            Log($"Error updating Redux: {e.Message}");
-            Log($"Stack Trace: {e.StackTrace}");
+            LogError($"Error updating Redux: {e.Message}", e);
             Log($"Redux may be in an invalid state, try uninstalling and reinstalling");
         }
         finally
@@ -565,6 +563,20 @@ public partial class HomeTabViewModel : ViewModelBase
     private void Log(string message)
     {
         _log.Info(message);
+        AppendToInstallLog(message);
+    }
+
+    // Real install/patch failures used to go through Log(), which always writes at Info - grepping a
+    // user's log file for "ERROR" to find out what went wrong turned up nothing, since the failure and
+    // its stack trace were filed alongside routine progress lines.
+    private void LogError(string message, Exception? exception = null)
+    {
+        _log.Error(message, exception);
+        AppendToInstallLog(message);
+    }
+
+    private void AppendToInstallLog(string message)
+    {
         bool queueUpdate;
         lock (_installLogLock)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -217,7 +217,17 @@ public partial class HomeTabViewModel : ViewModelBase
     [RelayCommand]
     public async Task LaunchGame()
     {
-        if (_ksp2InstallService.Ksp2 is null) return;
+        // Re-validate right before using it rather than trusting whatever was cached at the last
+        // refresh - the install could have been moved, had its drive ejected, or been deleted in
+        // the meantime if the app was left idle.
+        _ksp2InstallService.TryLoadKsp2Install();
+        if (_ksp2InstallService.Ksp2 is not { IsValid: true })
+        {
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Launch",
+                "KSP2 installation not detected. Please select a directory containing KSP2 on the settings tab.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
         var activeEntry = _ksp2InstallService.ActiveEntry;
         if (activeEntry is null) return;
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -250,6 +250,17 @@ public partial class HomeTabViewModel : ViewModelBase
             return;
         }
 
+        // IsValid only confirms the exe exists - it says nothing about whether we could actually
+        // read its version. Falling through without this check let Install/Update stay enabled with
+        // an unknown "from" version, which crashed or hung once clicked (see issue #26).
+        if (ksp2.GameVersion is null)
+        {
+            MainButtonEnabled = false;
+            MainButtonShown = MainButtonState.Launch;
+            MainButtonTooltip = "Couldn't detect the installed game version. Verifying game files through Steam/Epic, or reinstalling the game, may fix this.";
+            return;
+        }
+
         var selectedVersion = SelectedVersion;
         if (selectedVersion is null)
         {
@@ -371,7 +382,17 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             return;
         }
-        
+
+        // The main button should already be disabled whenever this is null (see
+        // UpdateMainButtonState), but guard here too rather than pass a null "from" version into
+        // GetPatchListToVersion, which assumes a real GameVersion and would throw or search a
+        // patch graph that was never meant to be reached from "unknown".
+        if (ksp2.GameVersion is null)
+        {
+            Log("Couldn't detect the installed game version, so it's unclear which patches to apply. Verifying game files, or reinstalling the game, may fix this.");
+            return;
+        }
+
         // Set up process cancellation trigger.
         MainButtonShown = MainButtonState.Cancel;
         MainButtonEnabled = true;
@@ -379,9 +400,9 @@ public partial class HomeTabViewModel : ViewModelBase
         _cancelCurrentOperation = new CancellationTokenSource();
 
         Log("Creating install plan");
-            
+
         var plan = _releasesFeedService.ReleasesFeed[SelectedVersion.Channel]
-            .GetPatchListToVersion(_ksp2InstallService.Ksp2!.GameVersion!, SelectedVersion.Version);
+            .GetPatchListToVersion(ksp2.GameVersion, SelectedVersion.Version);
         try
         {
             await RunPlanOnInstall(plan, ksp2);

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -384,6 +384,10 @@ public partial class HomeTabViewModel : ViewModelBase
         {
             Log("Installation cancelled");
         }
+        catch (InstallFailedException e)
+        {
+            Log(e.Message);
+        }
         catch (Exception e)
         {
             Log($"Error updating Redux: {e.Message}");
@@ -436,6 +440,10 @@ public partial class HomeTabViewModel : ViewModelBase
         catch (OperationCanceledException)
         {
             Log("Installation cancelled");
+        }
+        catch (InstallFailedException e)
+        {
+            Log(e.Message);
         }
         catch (Exception e)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -129,9 +129,19 @@ public partial class MainWindowViewModel : ViewModelBase
 
         timer.Tick += async (sender, args) =>
         {
-            if (!await _updateService.CheckAndPerformUpdateAsync()) HomeTab.DisableInstallation();
+            try
+            {
+                if (!await _updateService.CheckAndPerformUpdateAsync()) HomeTab.DisableInstallation();
+            }
+            catch (Exception ex)
+            {
+                // This is an async void-shaped event handler (DispatcherTimer.Tick), so an unhandled
+                // exception here would crash the whole app on a background tick unrelated to anything
+                // the user just did.
+                _log.Error("Periodic update check failed unexpectedly.", ex);
+            }
         };
-        
+
         timer.Start();
     }
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -262,9 +262,13 @@ public partial class MainWindowViewModel : ViewModelBase
 
         if (ksp2.VersionDetectionException is { } e)
         {
-            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Could not detect version",
-                $"{e.GetType().FullName}\n\n{e}", ButtonEnum.Ok,
-                windowStartupLocation: WindowStartupLocation.CenterOwner);
+            _log.Error("Could not detect the installed KSP2 version.", e);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Couldn't Detect Game Version",
+                "KSP2 Redux couldn't figure out which version of the game is installed. " +
+                "This can happen if the game files are missing, corrupted, or from an unsupported source.\n\n" +
+                "You can still try launching or installing, but update checks may be unreliable. " +
+                "Details were written to the log file (see Settings > Open Logs Folder) if you'd like to report this.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
         }
     }
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -38,10 +38,11 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IMessageBoxService _messageBoxService;
     private readonly ILogService _log;
 
-    [ObservableProperty] private InstallState _currentInstallState;
+    [ObservableProperty]
+    public partial InstallState CurrentInstallState { get; set; }
 
-    [ObservableProperty] private bool _isUpdateDownloading;
-
+    [ObservableProperty]
+    public partial bool IsUpdateDownloading { get; set; }
     public HomeTabViewModel HomeTab { get; }
     public CommunityTabViewModel CommunityTab { get; }
     public ModsTabViewModel ModsTab { get; }
@@ -49,13 +50,15 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public Shared.NewsCollectionViewModel NewsCollectionViewModel { get; }
 
-    [ObservableProperty] private int _currentTab;
+    [ObservableProperty]
+    public partial int CurrentTab { get; set; }
 
     // Drives the blurred backdrop behind whichever glass panel (Home log, Community
     // article, Settings, Mods) is currently on screen. Home and Community don't always
     // have one showing, so this has to react to their own visibility state too, not just
     // which tab is selected.
-    [ObservableProperty] private bool _isContentPanelVisible;
+    [ObservableProperty]
+    public partial bool IsContentPanelVisible { get; set; }
 
     public MainWindowViewModel(HomeTabViewModel homeTab, CommunityTabViewModel communityTab, ModsTabViewModel modsTab,
         SettingsTabViewModel settingsTabViewModel, IKsp2InstallService ksp2InstallService,

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -120,7 +120,7 @@ public partial class MainWindowViewModel : ViewModelBase
         };
         UpdateContentPanelVisible();
 
-        _ = InitializeAsync().ContinueWith(LogErrors);
+        _ = InitializeAsync().ContinueWith(HandleInitializeFailure);
 
         var timer = new DispatcherTimer
         {
@@ -141,6 +141,21 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             _log.Error("Background task faulted.", antecedent.Exception);
         }
+    }
+
+    // Startup initialization failing is more severe than a background task like the news feed
+    // failing to load (which just leaves a list empty) - if this throws, feeds/install detection/
+    // the update check may not have run at all, so tell the user instead of failing silently.
+    private void HandleInitializeFailure(Task antecedent)
+    {
+        if (!antecedent.IsFaulted) return;
+        _log.Error("Startup initialization failed.", antecedent.Exception);
+        Dispatcher.UIThread.Post(async () =>
+        {
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Startup Error",
+                "Something went wrong while starting up, so setup may be incomplete (feeds, install detection, or the update check may not have run). Check the log file for details, and consider restarting the launcher.",
+                ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+        });
     }
 
     private async Task InitializeAsync()

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -153,6 +153,9 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
+    public Task LaunchExternalLinkAsync(TopLevel? topLevel, string url)
+        => ExternalLinkLauncher.LaunchAsync(topLevel, url, _messageBoxService, _log);
+
     // Startup initialization failing is more severe than a background task like the news feed
     // failing to load (which just leaves a list empty) - if this throws, feeds/install detection/
     // the update check may not have run at all, so tell the user instead of failing silently.
@@ -278,7 +281,7 @@ public partial class MainWindowViewModel : ViewModelBase
         List<News> newsList = await _newsService.FindAllNews();
         foreach (News news in newsList)
         {
-            _newsCollectionService.Add(new Shared.NewsItemViewModel(_newsService, news));
+            _newsCollectionService.Add(new Shared.NewsItemViewModel(news));
         }
 
         MaybeAutoSelectLatestCommunityNews();

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO.Abstractions;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.Services;
@@ -7,6 +9,7 @@ namespace Ksp2Redux.Tools.Launcher.ViewModels.Settings;
 
 public partial class Ksp2InstallRowViewModel : ViewModelBase
 {
+    private readonly IFileSystem _fileSystem;
     private readonly IKsp2InstallService _ksp2InstallService;
     private readonly Ksp2InstallEntry _entry;
 
@@ -17,6 +20,9 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
 
     [ObservableProperty]
     public partial string ExePath { get; set; }
+
+    [ObservableProperty]
+    public partial string? ExePathError { get; set; }
 
     [ObservableProperty]
     public partial string ReleaseChannel { get; set; }
@@ -31,13 +37,17 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
     public partial string SteamAppId { get; set; }
 
     [ObservableProperty]
+    public partial string? SteamAppIdError { get; set; }
+
+    [ObservableProperty]
     public partial string LaunchArguments { get; set; }
 
     [ObservableProperty]
     public partial bool DisableGraphicsJobs { get; set; }
 
-    public Ksp2InstallRowViewModel(IKsp2InstallService ksp2InstallService, Ksp2InstallEntry entry, bool isActive)
+    public Ksp2InstallRowViewModel(IFileSystem fileSystem, IKsp2InstallService ksp2InstallService, Ksp2InstallEntry entry, bool isActive)
     {
+        _fileSystem = fileSystem;
         _ksp2InstallService = ksp2InstallService;
         _entry = entry;
         Name = entry.Name;
@@ -48,10 +58,17 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
         SteamAppId = entry.SteamAppId;
         LaunchArguments = entry.LaunchArguments;
         DisableGraphicsJobs = entry.DisableGraphicsJobs;
+
+        ExePathError = ValidateExePath(ExePath);
+        SteamAppIdError = ValidateSteamAppId(SteamAppId);
     }
 
     partial void OnNameChanged(string value) => _ksp2InstallService.RenameInstall(_entry.Id, value);
-    partial void OnExePathChanged(string value) => _ksp2InstallService.UpdateInstallExePath(_entry.Id, value);
+    partial void OnExePathChanged(string value)
+    {
+        ExePathError = ValidateExePath(value);
+        _ksp2InstallService.UpdateInstallExePath(_entry.Id, value);
+    }
     partial void OnReleaseChannelChanged(string value)
     {
         if (string.IsNullOrEmpty(value)) return;
@@ -72,6 +89,7 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
     partial void OnSteamAppIdChanged(string value)
     {
         var normalized = value?.Trim() ?? "";
+        SteamAppIdError = ValidateSteamAppId(normalized);
         if (_entry.SteamAppId == normalized) return;
         _entry.SteamAppId = normalized;
         _ksp2InstallService.NotifyInstallChanged(_entry.Id);
@@ -87,4 +105,18 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
 
     partial void OnDisableGraphicsJobsChanged(bool value)
         => _ksp2InstallService.UpdateInstallDisableGraphicsJobs(_entry.Id, value);
+
+    private string? ValidateExePath(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "An install path is required.";
+        if (_fileSystem.Path.GetFileName(value) != Ksp2Install.KSP2_EXE_NAME) return $"Path must point to {Ksp2Install.KSP2_EXE_NAME}.";
+        if (!_fileSystem.File.Exists(value)) return "That file doesn't exist.";
+        return null;
+    }
+
+    private static string? ValidateSteamAppId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return value.All(char.IsAsciiDigit) ? null : "Steam App ID must be numeric.";
+    }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/Ksp2InstallRowViewModel.cs
@@ -12,14 +12,29 @@ public partial class Ksp2InstallRowViewModel : ViewModelBase
 
     public Guid Id => _entry.Id;
 
-    [ObservableProperty] private string _name;
-    [ObservableProperty] private string _exePath;
-    [ObservableProperty] private string _releaseChannel;
-    [ObservableProperty] private bool _isActive;
-    [ObservableProperty] private bool _launchThroughSteam;
-    [ObservableProperty] private string _steamAppId;
-    [ObservableProperty] private string _launchArguments;
-    [ObservableProperty] private bool _disableGraphicsJobs;
+    [ObservableProperty]
+    public partial string Name { get; set; }
+
+    [ObservableProperty]
+    public partial string ExePath { get; set; }
+
+    [ObservableProperty]
+    public partial string ReleaseChannel { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsActive { get; set; }
+
+    [ObservableProperty]
+    public partial bool LaunchThroughSteam { get; set; }
+
+    [ObservableProperty]
+    public partial string SteamAppId { get; set; }
+
+    [ObservableProperty]
+    public partial string LaunchArguments { get; set; }
+
+    [ObservableProperty]
+    public partial bool DisableGraphicsJobs { get; set; }
 
     public Ksp2InstallRowViewModel(IKsp2InstallService ksp2InstallService, Ksp2InstallEntry entry, bool isActive)
     {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -25,6 +25,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     private readonly HomeTabViewModel _homeTabViewModel;
     private readonly IAssemblyService _assemblyService;
     private readonly IMessageBoxService _messageBoxService;
+    private readonly ILogService _log;
 
     public ObservableCollection<Ksp2InstallRowViewModel> Installs { get; } = [];
     public bool ChannelsLoaded = false;
@@ -61,7 +62,8 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     public SettingsTabViewModel(IFileSystem fileSystem, ICacheService cacheService, ILauncherConfigService launcherConfigService,
         IKsp2InstallService ksp2InstallService,
-        ITabNavigatorService tabNavigatorService, HomeTabViewModel homeTabViewModel, IAssemblyService assemblyService, IMessageBoxService messageBoxService)
+        ITabNavigatorService tabNavigatorService, HomeTabViewModel homeTabViewModel, IAssemblyService assemblyService,
+        IMessageBoxService messageBoxService, ILogService log)
     {
         _fileSystem = fileSystem;
         _cacheService = cacheService;
@@ -71,6 +73,7 @@ public partial class SettingsTabViewModel : ViewModelBase
         _homeTabViewModel = homeTabViewModel;
         _assemblyService = assemblyService;
         _messageBoxService = messageBoxService;
+        _log = log;
 
         _ksp2InstallService.InstallsChanged += (_, _) => RebuildInstalls();
         _ksp2InstallService.ActiveInstallChanged += (_, _) => SyncSelectedInstall();
@@ -134,7 +137,18 @@ public partial class SettingsTabViewModel : ViewModelBase
     [RelayCommand]
     public async Task AddInstall()
     {
-        var chosenPath = await DoOpenFilePickerAsync();
+        IStorageFile? chosenPath;
+        try
+        {
+            chosenPath = await DoOpenFilePickerAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Failed to open the file picker for adding an install.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
         if (chosenPath is null) return;
 
         var path = chosenPath.Path.LocalPath;
@@ -159,7 +173,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     {
         if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop ||
             desktop.MainWindow?.StorageProvider is not { } provider)
-            throw new NullReferenceException("Missing StorageProvider instance.");
+            throw new InvalidOperationException("Could not access the file picker (no active window).");
 
         IStorageFolder? startFolder = null;
         var lastKnownPath = _ksp2InstallService.ActiveEntry?.ExePath;
@@ -201,7 +215,18 @@ public partial class SettingsTabViewModel : ViewModelBase
             ButtonEnum.YesNo, windowStartupLocation:WindowStartupLocation.CenterOwner);
         if (result != ButtonResult.Yes) return;
 
-        _cacheService.RecursivelyRestoreCache(installDir);
+        try
+        {
+            _cacheService.RecursivelyRestoreCache(installDir);
+        }
+        catch (Exception ex)
+        {
+            _log.Error($"Failed to uninstall Redux from {installDir}.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't uninstall Redux: {ex.Message}",
+                windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
 
         _ksp2InstallService.TryLoadKsp2Install();
         await _homeTabViewModel.UpdateVersionsList();
@@ -212,7 +237,18 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     public async Task InstallFromPatchFile()
     {
-        var chosenPath = await DoOpenPatchFilePickerAsync();
+        IStorageFile? chosenPath;
+        try
+        {
+            chosenPath = await DoOpenPatchFilePickerAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Failed to open the file picker for a patch file.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+            return;
+        }
 
         if (chosenPath is null) return;
 
@@ -226,7 +262,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     {
         if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop ||
             desktop.MainWindow?.StorageProvider is not { } provider)
-            throw new NullReferenceException("Missing StorageProvider instance.");
+            throw new InvalidOperationException("Could not access the file picker (no active window).");
         var startFolder = await provider.TryGetWellKnownFolderAsync(WellKnownFolder.Downloads);
 
         var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions()

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -48,6 +48,9 @@ public partial class SettingsTabViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool VerboseLogging { get; set; }
 
+    [ObservableProperty]
+    public partial bool IsAddingInstall { get; set; }
+
     public string LauncherVersion => _assemblyService.GetVersion()?.ToString(4) ?? "?";
 
     private bool _suppressActiveSync;
@@ -123,7 +126,7 @@ public partial class SettingsTabViewModel : ViewModelBase
             Installs.Clear();
             foreach (var entry in entries)
             {
-                Installs.Add(new Ksp2InstallRowViewModel(_ksp2InstallService, entry, entry.Id == activeId));
+                Installs.Add(new Ksp2InstallRowViewModel(_fileSystem, _ksp2InstallService, entry, entry.Id == activeId));
             }
         }
         SyncSelectedInstall();
@@ -160,36 +163,52 @@ public partial class SettingsTabViewModel : ViewModelBase
     [RelayCommand]
     public async Task AddInstall()
     {
-        IStorageFile? chosenPath;
+        if (IsAddingInstall) return;
+        IsAddingInstall = true;
         try
         {
-            chosenPath = await DoOpenFilePickerAsync();
-        }
-        catch (Exception ex)
-        {
-            _log.Error("Failed to open the file picker for adding an install.", ex);
-            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
-                $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
-            return;
-        }
-        if (chosenPath is null) return;
+            IStorageFile? chosenPath;
+            try
+            {
+                chosenPath = await DoOpenFilePickerAsync();
+            }
+            catch (Exception ex)
+            {
+                _log.Error("Failed to open the file picker for adding an install.", ex);
+                await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                    $"Couldn't open the file picker: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+                return;
+            }
+            if (chosenPath is null) return;
 
-        var path = chosenPath.Path.LocalPath;
-        var existing = _ksp2InstallService.Entries.FirstOrDefault(e =>
-            string.Equals(e.ExePath, path, StringComparison.OrdinalIgnoreCase));
-        if (existing is not null)
-        {
-            _ksp2InstallService.SetActiveInstall(existing.Id);
-            return;
+            var path = chosenPath.Path.LocalPath;
+            var existing = _ksp2InstallService.Entries.FirstOrDefault(e =>
+                string.Equals(e.ExePath, path, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null)
+            {
+                _ksp2InstallService.SetActiveInstall(existing.Id);
+                return;
+            }
+            _ksp2InstallService.AddInstall(path);
         }
-        _ksp2InstallService.AddInstall(path);
+        finally
+        {
+            IsAddingInstall = false;
+        }
     }
 
     [RelayCommand]
-    public void RemoveSelectedInstall()
+    public async Task RemoveSelectedInstall()
     {
         if (Installs.Count <= 1) return;
-        if (SelectedInstall is { } row) _ksp2InstallService.RemoveInstall(row.Id);
+        if (SelectedInstall is not { } row) return;
+
+        var result = await _messageBoxService.ShowMessageBoxAsOwnedAsync("Confirm",
+            $"Are you sure you want to remove \"{row.Name}\"? Its name, launch arguments, and Steam settings will be lost.",
+            ButtonEnum.YesNo, windowStartupLocation: WindowStartupLocation.CenterOwner);
+        if (result != ButtonResult.Yes) return;
+
+        _ksp2InstallService.RemoveInstall(row.Id);
     }
 
     public async Task<IStorageFile?> DoOpenFilePickerAsync()

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -3,8 +3,11 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -25,6 +28,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     private readonly HomeTabViewModel _homeTabViewModel;
     private readonly IAssemblyService _assemblyService;
     private readonly IMessageBoxService _messageBoxService;
+    private readonly IEnvironmentProvider _environmentProvider;
     private readonly ILogService _log;
 
     public ObservableCollection<Ksp2InstallRowViewModel> Installs { get; } = [];
@@ -40,6 +44,9 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     [ObservableProperty]
     public partial bool CanRemoveSelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool VerboseLogging { get; set; }
 
     public string LauncherVersion => _assemblyService.GetVersion()?.ToString(4) ?? "?";
 
@@ -63,7 +70,7 @@ public partial class SettingsTabViewModel : ViewModelBase
     public SettingsTabViewModel(IFileSystem fileSystem, ICacheService cacheService, ILauncherConfigService launcherConfigService,
         IKsp2InstallService ksp2InstallService,
         ITabNavigatorService tabNavigatorService, HomeTabViewModel homeTabViewModel, IAssemblyService assemblyService,
-        IMessageBoxService messageBoxService, ILogService log)
+        IMessageBoxService messageBoxService, IEnvironmentProvider environmentProvider, ILogService log)
     {
         _fileSystem = fileSystem;
         _cacheService = cacheService;
@@ -73,11 +80,27 @@ public partial class SettingsTabViewModel : ViewModelBase
         _homeTabViewModel = homeTabViewModel;
         _assemblyService = assemblyService;
         _messageBoxService = messageBoxService;
+        _environmentProvider = environmentProvider;
         _log = log;
 
         _ksp2InstallService.InstallsChanged += (_, _) => RebuildInstalls();
         _ksp2InstallService.ActiveInstallChanged += (_, _) => SyncSelectedInstall();
         RebuildInstalls();
+
+        _suppressVerboseLoggingSave = true;
+        try { VerboseLogging = _launcherConfigService.Config.VerboseLogging; }
+        finally { _suppressVerboseLoggingSave = false; }
+        _log.MinimumLevel = VerboseLogging ? LogLevel.Debug : LogLevel.Info;
+    }
+
+    private bool _suppressVerboseLoggingSave;
+
+    partial void OnVerboseLoggingChanged(bool value)
+    {
+        _log.MinimumLevel = value ? LogLevel.Debug : LogLevel.Info;
+        if (_suppressVerboseLoggingSave) return;
+        _launcherConfigService.Config.VerboseLogging = value;
+        _launcherConfigService.Save();
     }
 
     private void RebuildInstalls()
@@ -274,5 +297,68 @@ public partial class SettingsTabViewModel : ViewModelBase
         });
 
         return files?.Count >= 1 ? files[0] : null;
+    }
+
+    public async Task OpenLogsFolder()
+    {
+        try
+        {
+            var logsDir = LocalStoragePaths.GetLogsDirectory(_fileSystem, _environmentProvider);
+            _fileSystem.Directory.CreateDirectory(logsDir);
+            Process.Start(new ProcessStartInfo(logsDir) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            _log.Error("Failed to open the logs folder.", ex);
+            await _messageBoxService.ShowMessageBoxAsOwnedAsync("Error!",
+                $"Couldn't open the logs folder: {ex.Message}", windowStartupLocation: WindowStartupLocation.CenterOwner);
+        }
+    }
+
+    /// <summary>
+    /// Everything a bug report needs in one paste-ready block: launcher version, active install
+    /// details, OS, and the tail of the current log file - so a support conversation doesn't have to
+    /// start with four separate questions before diagnosis can even begin.
+    /// </summary>
+    public string BuildDiagnosticInfo()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"KSP2 Redux Launcher v{LauncherVersion}");
+        sb.AppendLine($"OS: {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
+
+        if (_ksp2InstallService.ActiveEntry is { } entry)
+        {
+            sb.AppendLine($"Active install: {entry.Name} (channel={entry.ReleaseChannel}, launchThroughSteam={entry.LaunchThroughSteam})");
+            sb.AppendLine($"Exe path: {entry.ExePath}");
+            var ksp2 = _ksp2InstallService.Ksp2;
+            sb.AppendLine(ksp2 is { IsValid: true }
+                ? $"Detected: {ksp2.Distribution}, version {ksp2.GameVersion}"
+                : "Detected: (not currently detected as valid)");
+        }
+        else
+        {
+            sb.AppendLine("Active install: (none configured)");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("--- Recent log ---");
+        try
+        {
+            if (_log.CurrentLogFilePath is { } logPath && _fileSystem.File.Exists(logPath))
+            {
+                var lines = _fileSystem.File.ReadAllLines(logPath);
+                sb.AppendLine(string.Join(_environmentProvider.NewLine, lines.TakeLast(100)));
+            }
+            else
+            {
+                sb.AppendLine("(no log file available)");
+            }
+        }
+        catch (Exception ex)
+        {
+            sb.AppendLine($"(could not read log file: {ex.Message})");
+        }
+
+        return sb.ToString();
     }
 }

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Settings/SettingsTabViewModel.cs
@@ -31,9 +31,14 @@ public partial class SettingsTabViewModel : ViewModelBase
 
     public ObservableCollection<string> ValidChannels { get; } = [];
 
-    [ObservableProperty] private Ksp2InstallRowViewModel? _selectedInstall;
-    [ObservableProperty] private bool _hasSelectedInstall;
-    [ObservableProperty] private bool _canRemoveSelectedInstall;
+    [ObservableProperty]
+    public partial Ksp2InstallRowViewModel? SelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool HasSelectedInstall { get; set; }
+
+    [ObservableProperty]
+    public partial bool CanRemoveSelectedInstall { get; set; }
 
     public string LauncherVersion => _assemblyService.GetVersion()?.ToString(4) ?? "?";
 

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Shared/NewsItemViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Shared/NewsItemViewModel.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using Ksp2Redux.Tools.Launcher.Models;
-using Ksp2Redux.Tools.Launcher.Services;
 
 namespace Ksp2Redux.Tools.Launcher.ViewModels.Shared;
 
-public class NewsItemViewModel(INewsService newsService, News news) : ViewModelBase
+public class NewsItemViewModel(News news) : ViewModelBase
 {
     public News News { get; set; } = news;
-    public int NewsId => newsService.GetNewsId(News);
+    public string NewsId => News.Id;
 
     public string Title => News.Title;
 

--- a/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/CommunityTabView.axaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels.Community;
@@ -13,16 +12,8 @@ public partial class CommunityTabView : UserControl
 
     public CommunityTabView() => AvaloniaXamlLoader.Load(this);
 
-    private void LaunchUri(Uri uri)
+    private async void NewsLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        TopLevel.GetTopLevel(this)!.Launcher.LaunchUriAsync(uri);
-    }
-
-    private void NewsLink_OnClick(object? sender, RoutedEventArgs e)
-    {
-        if (ViewModel.SelectedNews.Link is null)
-            return;
-        
-        LaunchUri(new Uri(ViewModel.SelectedNews.Link));
+        await ViewModel.LaunchExternalLinkAsync(TopLevel.GetTopLevel(this), ViewModel.SelectedNews.Link);
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
@@ -113,11 +113,20 @@
 				</Grid>
 			</Grid>
 
-			<TextBlock Grid.Row="2"
-			           FontFamily="{StaticResource JetBrainsMonoLight}" FontSize="11"
-			           Foreground="{StaticResource TextFaintBrush}"
-			           HorizontalAlignment="Right" Margin="0,12,0,0"
-			           Text="{Binding LauncherVersion, StringFormat='Launcher v{0}'}" />
+			<Grid Grid.Row="2" ColumnDefinitions="Auto,Auto,Auto,*" ColumnSpacing="10" Margin="0,12,0,0">
+				<Button Grid.Column="0" FontSize="11" Padding="8,4" Click="OpenLogsFolderClick">Open Logs Folder</Button>
+				<Button Grid.Column="1" FontSize="11" Padding="8,4" Click="CopyDiagnosticInfoClick">Copy Diagnostic Info</Button>
+				<CheckBox Grid.Column="2" FontSize="11" VerticalAlignment="Center"
+				          IsChecked="{Binding VerboseLogging, Mode=TwoWay}"
+				          ToolTip.Tip="Write more detailed information to the log file. Useful when troubleshooting an issue.">
+					Verbose logging
+				</CheckBox>
+				<TextBlock Grid.Column="3"
+				           FontFamily="{StaticResource JetBrainsMonoLight}" FontSize="11"
+				           Foreground="{StaticResource TextFaintBrush}"
+				           HorizontalAlignment="Right" VerticalAlignment="Center"
+				           Text="{Binding LauncherVersion, StringFormat='Launcher v{0}'}" />
+			</Grid>
 		</Grid>
 		</Border>
 	</Grid>

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:settings="clr-namespace:Ksp2Redux.Tools.Launcher.ViewModels.Settings"
+             xmlns:conv="clr-namespace:Avalonia.Data.Converters;assembly=Avalonia.Base"
              x:DataType="settings:SettingsTabViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Ksp2Redux.Tools.Launcher.Views.SettingsTabView"
@@ -23,7 +24,7 @@
 
 			<Grid Grid.Row="1"
 			      ColumnDefinitions="Auto,*"
-			      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+			      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
 			      ColumnSpacing="10" RowSpacing="6">
 
 				<TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center">Editing install</TextBlock>
@@ -39,7 +40,8 @@
 				</ComboBox>
 
 				<StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Spacing="6" HorizontalAlignment="Left">
-					<Button Command="{Binding AddInstallCommand}" ToolTip.Tip="Add a KSP2 install">Add</Button>
+					<Button Command="{Binding AddInstallCommand}" IsEnabled="{Binding !IsAddingInstall}"
+					        ToolTip.Tip="Add a KSP2 install">Add</Button>
 					<Button Classes="danger"
 					        Command="{Binding RemoveSelectedInstallCommand}"
 					        IsEnabled="{Binding CanRemoveSelectedInstall}"
@@ -61,49 +63,57 @@
 				         PlaceholderText="C:\Steam\SteamGames\KSP2\KSP2_x64.exe"
 				         FontFamily="{StaticResource JetBrainsMonoLight}" FontSize="11" />
 
-				<TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="4" Grid.Column="1" FontSize="11" Foreground="{StaticResource DangerBrush}"
+				           IsVisible="{Binding SelectedInstall.ExePathError, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}"
+				           Text="{Binding SelectedInstall.ExePathError}" TextWrapping="Wrap" />
+
+				<TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}">Release channel</TextBlock>
-				<ComboBox Grid.Row="4" Grid.Column="1" HorizontalAlignment="Stretch"
+				<ComboBox Grid.Row="5" Grid.Column="1" HorizontalAlignment="Stretch"
 				          Name="ReleaseChannelSelector"
 				          IsVisible="{Binding HasSelectedInstall}"
 				          MaxDropDownHeight="200"
 				          SelectedValue="{Binding SelectedInstall.ReleaseChannel, Mode=TwoWay}"
 				          ItemsSource="{Binding ValidChannels}" />
 
-				<TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}">Launch through Steam</TextBlock>
-				<CheckBox Grid.Row="5" Grid.Column="1" HorizontalAlignment="Left"
+				<CheckBox Grid.Row="6" Grid.Column="1" HorizontalAlignment="Left"
 				          IsVisible="{Binding HasSelectedInstall}"
 				          IsChecked="{Binding SelectedInstall.LaunchThroughSteam, Mode=TwoWay}" />
 
-				<TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}"
 				           ToolTip.Tip="Override to launch a Steam 'Add a Non-Steam Game' shortcut for KSP2. Leave as 954850 for the normal Steam release.">Steam app id</TextBlock>
-				<TextBox Grid.Row="6" Grid.Column="1" HorizontalAlignment="Stretch"
+				<TextBox Grid.Row="7" Grid.Column="1" HorizontalAlignment="Stretch"
 				         IsVisible="{Binding HasSelectedInstall}"
 				         PlaceholderText="954850"
 				         Text="{Binding SelectedInstall.SteamAppId, Mode=TwoWay}"
 				         IsEnabled="{Binding SelectedInstall.LaunchThroughSteam}" />
 
-				<TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="8" Grid.Column="1" FontSize="11" Foreground="{StaticResource DangerBrush}"
+				           IsVisible="{Binding SelectedInstall.SteamAppIdError, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}"
+				           Text="{Binding SelectedInstall.SteamAppIdError}" TextWrapping="Wrap" />
+
+				<TextBlock Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}"
 				           ToolTip.Tip="Arguments passed to KSP2_x64.exe on launch. Ignored when 'Launch through Steam' is enabled.">Launch arguments</TextBlock>
-				<TextBox Grid.Row="7" Grid.Column="1" HorizontalAlignment="Stretch"
+				<TextBox Grid.Row="9" Grid.Column="1" HorizontalAlignment="Stretch"
 				         IsVisible="{Binding HasSelectedInstall}"
 				         Text="{Binding SelectedInstall.LaunchArguments, Mode=TwoWay}"
 				         IsEnabled="{Binding !SelectedInstall.LaunchThroughSteam}" />
 
-				<TextBlock Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"
+				<TextBlock Grid.Row="10" Grid.Column="0" VerticalAlignment="Center"
 				           IsVisible="{Binding HasSelectedInstall}"
 				           ToolTip.Tip="Sets gfx-enable-gfx-jobs=0 in boot.config. Workaround for crashes on some hardware.">Disable graphics jobs</TextBlock>
-				<CheckBox Grid.Row="8" Grid.Column="1" HorizontalAlignment="Left"
+				<CheckBox Grid.Row="10" Grid.Column="1" HorizontalAlignment="Left"
 				          IsVisible="{Binding HasSelectedInstall}"
 				          IsChecked="{Binding SelectedInstall.DisableGraphicsJobs, Mode=TwoWay}" />
 
-				<Separator Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" Margin="0 4 0 4"
+				<Separator Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="2" Margin="0 4 0 4"
 				           IsVisible="{Binding HasSelectedInstall}" />
 
-				<Grid Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2"
+				<Grid Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2"
 				      ColumnDefinitions="*,*" ColumnSpacing="10"
 				      IsVisible="{Binding HasSelectedInstall}">
 					<Button Grid.Column="0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"

--- a/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/SettingsTabView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Ksp2Redux.Tools.Launcher.ViewModels.Settings;
@@ -20,5 +21,18 @@ public partial class SettingsTabView : UserControl
     private async void InstallFromPatchFile(object? sender, RoutedEventArgs e)
     {
         await Model.InstallFromPatchFile();
+    }
+
+    private async void OpenLogsFolderClick(object? sender, RoutedEventArgs e)
+    {
+        await Model.OpenLogsFolder();
+    }
+
+    private async void CopyDiagnosticInfoClick(object? sender, RoutedEventArgs e)
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+        var clipboard = topLevel?.Clipboard;
+        if (clipboard is null) return;
+        await clipboard.SetTextAsync(Model.BuildDiagnosticInfo());
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/Shared/NewsItemView.axaml.cs
@@ -26,7 +26,7 @@ public partial class NewsItemView : UserControl
         var communityTab = mainWindow.FindControl<TabItem>("CommunityTab");
         if (mainTabControl is null || communityTab is null) return;
 
-        mainWindowViewModel.CommunityTab.SetSelectedNewsId(ViewModel?.NewsId ?? -1);
+        mainWindowViewModel.CommunityTab.SetSelectedNewsId(ViewModel?.NewsId);
         mainTabControl.SelectedItem = communityTab;
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
@@ -174,6 +174,12 @@
                     VerticalAlignment="Stretch"
                     Margin="6,0,0,0" />
             </Grid>
+            <TextBlock Name="FeedRefreshWarning"
+                       IsVisible="{Binding FeedRefreshFailed}"
+                       Text="Couldn't refresh versions - showing the last known list."
+                       Foreground="{StaticResource WarningBrush}"
+                       FontSize="10" TextWrapping="Wrap"
+                       Margin="2,4,0,0" />
           </StackPanel>
         </StackPanel>
 

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml
@@ -186,7 +186,8 @@
         <Panel Grid.Row="3" DataContext="{Binding HomeTab}">
           <Panel x:DataType="home:HomeTabViewModel">
             <Button Classes="main-button" IsVisible="True" Name="InstallButton" Command="{Binding InstallRedux}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-install.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />
@@ -194,7 +195,8 @@
                 </Canvas>
             </Button>
             <Button Classes="main-button" IsVisible="False" Name="UpdateButton" Command="{Binding UpdateRedux}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-update.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />
@@ -202,7 +204,8 @@
                 </Canvas>
             </Button>
             <Button Classes="main-button" IsVisible="False" Name="CancelButton" ClickMode="Press" Command="{Binding CancelCurrentMainButtonAction}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-cancel.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />
@@ -210,7 +213,8 @@
                 </Canvas>
             </Button>
             <Button Classes="main-button" IsVisible="False" Name="LaunchButton" Command="{Binding LaunchGame}"
-                    IsEnabled="{Binding MainButtonEnabled}">
+                    IsEnabled="{Binding MainButtonEnabled}"
+                    ToolTip.Tip="{Binding MainButtonTooltip}" ToolTip.ShowOnDisabled="True">
                 <Canvas Width="260" Height="76">
                     <Image Source="avares://Ksp2Redux.Tools.Launcher/Assets/button-launch.png" Canvas.Left="0" Canvas.Top="0" Width="260" />
                     <Border Classes="main-button-tint" Width="260" Height="76" CornerRadius="{StaticResource RadiusMedium}" />

--- a/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/SidebarView.axaml.cs
@@ -11,6 +11,7 @@ namespace Ksp2Redux.Tools.Launcher.Views;
 public partial class SidebarView : UserControl
 {
     private HomeTabViewModel? Model => (DataContext as MainWindowViewModel)?.HomeTab;
+    private MainWindowViewModel? MainViewModel => DataContext as MainWindowViewModel;
     private Button? LaunchButtonControl => this.FindControl<Button>("LaunchButton");
     private Button? UpdateButtonControl => this.FindControl<Button>("UpdateButton");
     private Button? CancelButtonControl => this.FindControl<Button>("CancelButton");
@@ -71,43 +72,44 @@ public partial class SidebarView : UserControl
         }
     }
 
-    private void LaunchUri(Uri uri)
+    private async void LaunchUri(string url)
     {
-        TopLevel.GetTopLevel(this)!.Launcher.LaunchUriAsync(uri);
+        if (MainViewModel is not { } model) return;
+        await model.LaunchExternalLinkAsync(TopLevel.GetTopLevel(this), url);
     }
 
     private void WebsiteLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://ksp2redux.org"));
+        LaunchUri("https://ksp2redux.org");
     }
 
     private void DiscordLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://discord.gg/8yq8d5VGQR"));
+        LaunchUri("https://discord.gg/8yq8d5VGQR");
     }
 
     private void TikTokLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://tiktok.com/@ksp2redux"));
+        LaunchUri("https://tiktok.com/@ksp2redux");
     }
 
     private void RedditLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://reddit.com/r/KSP2Redux"));
+        LaunchUri("https://reddit.com/r/KSP2Redux");
     }
 
     private void ForumsLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://forum.kerbalspaceprogram.com/topic/226985-ksp2-redux"));
+        LaunchUri("https://forum.kerbalspaceprogram.com/topic/226985-ksp2-redux");
     }
 
     private void YoutubeLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://www.youtube.com/@RendezvousEntertainmentModding"));
+        LaunchUri("https://www.youtube.com/@RendezvousEntertainmentModding");
     }
 
     private void GithubLink_OnClick(object? sender, RoutedEventArgs e)
     {
-        LaunchUri(new Uri("https://github.com/KSP2Redux"));
+        LaunchUri("https://github.com/KSP2Redux");
     }
 }

--- a/Ksp2Redux.Tools.Launcher/app.manifest
+++ b/Ksp2Redux.Tools.Launcher/app.manifest
@@ -16,7 +16,7 @@
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of the Windows versions that this application has been tested on
-           and is designed to work with. Uncomment the appropriate elements
+           and is designed to work with. Uncomment the appropriate elements, 
            and Windows will automatically select the most compatible environment. -->
 
       <!-- Windows 10 -->

--- a/Ksp2Redux.Tools.Launcher/app.manifest
+++ b/Ksp2Redux.Tools.Launcher/app.manifest
@@ -16,11 +16,19 @@
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of the Windows versions that this application has been tested on
-           and is designed to work with. Uncomment the appropriate elements, 
+           and is designed to work with. Uncomment the appropriate elements,
            and Windows will automatically select the most compatible environment. -->
 
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+
+  <!-- A deeply nested Steam library combined with a long username/mod path could otherwise
+       approach the legacy 260-character MAX_PATH limit during patch extraction. -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/Ksp2Redux.Tools.Uploader/Program.cs
+++ b/Ksp2Redux.Tools.Uploader/Program.cs
@@ -103,13 +103,21 @@ if (!isDeleteOnly)
 
         var asset = await github.Repository.Release.UploadAsset(createdRelease, upload);
 
+        var localSize = new FileInfo(patch.File).Length;
+        if (asset.Size != localSize)
+        {
+            throw new InvalidOperationException(
+                $"Uploaded asset '{fileName}' reports size {asset.Size} bytes on GitHub, but the local file is {localSize} bytes. " +
+                "The upload may have been truncated or corrupted - not publishing this release.");
+        }
+
         var releasePatch = new ReleasePatch
         {
             Version = uploadManifest.Version,
             Label = uploadManifest.Label,
             ReleasedAt = DateTime.UtcNow,
             ChecksumSha256 = GetChecksum(patch.File),
-            Size = new FileInfo(patch.File).Length,
+            Size = localSize,
             Requires = new PatchRequirement
             {
                 Version = patch.PreviousVersion,


### PR DESCRIPTION
# v0.2.0: The Bulletproofing Update

This one's not about new features, it's about making sure the launcher doesn't screw you over. I went through basically every way this thing could crash, corrupt an install, or leave you staring at a raw exception with no idea what happened, and fixed them one by one. It ended up being a much bigger pass than I expected going in.

## The headline fix

Issue #26 is closed. The crash on version detection (`Sequence contains no matching element`) and the freeze that followed it once you dismissed the error are both gone. Turns out the launcher was happily letting you hit Install/Update even when it had no idea what version of the game you actually had, and then choking on that missing information. It now just tells you it couldn't detect your version and stops you from doing anything until that's sorted, instead of pretending everything's fine and falling over later.

## Stopping the crashes

Six of the most common ways the launcher could throw an unhandled exception at you are now handled properly: saving your settings, launching the game, starting up for the first time, uninstalling, and a few others all catch their own failures now and tell you what went wrong instead of taking the whole app down with them.

## Making the install itself safe

This is the part I care about most. The patch/install pipeline used to open the actual game file with `FileMode.Create`, which truncates it to zero bytes immediately, before anything new was even written or checked. If your disk was full or the launcher crashed mid write, you were left with a corrupted file, and the safety check that was supposed to catch a bad file ran after the damage was already done. Every write now goes to a separate file first, gets fully verified, and only then gets swapped in atomically. Your real files never get touched until the replacement is already known good.

Also fixed:
- Patch entries are checked to make sure they can't write or delete anything outside your install folder, in case a corrupted or tampered manifest ever tried to reference something like `../../../whatever`
- File writes now retry with backoff instead of giving up instantly, since antivirus or the game itself locking a file for a moment is common and usually resolves on its own
- Retrying a failed install no longer redownloads and reapplies files that already finished correctly
- Every downloaded patch gets its checksum verified
- A free disk space check runs before install/update so you don't end up with a half written mess because you ran out of room
- A failed install now rolls back to your last known good state instead of leaving things half patched
- Cancelling an install yourself is now treated as a normal outcome, not an error

## Making it actually debuggable

If something does go wrong, there's now a real way to figure out why. Settings has new "Open Logs Folder" and "Copy Diagnostic Info" buttons, the latter bundles your launcher version, install details, OS info, and a log tail into one clipboard ready block for bug reports. Real errors are now logged distinctly from routine progress messages instead of all blending together. Raw exception dumps got replaced with plain language explanations where it made sense. There's also a Verbose Logging setting now if you need more detail while chasing something down.

## Settings got hardened

Typing garbage into the install path or Steam App ID field used to fail silently and then show up later as a confusing "installation not detected" with no obvious cause. Both are validated inline now. Deleting an install asks for confirmation first since it permanently wipes its name, launch args, and Steam settings. Double clicking Add Install fast can't open two file pickers anymore either.

## Community tab and news polish

Every social/news link now goes through one shared launcher that validates the URL and tells you if it fails to open, instead of potentially throwing straight from a click. News posts are addressed by a stable ID instead of their position in the list, so refreshing the feed can't make you open the wrong article anymore. A single bad RSS entry with a missing date no longer takes down the entire news list with it.

## Smaller stuff

Network requests to fetch manifests, patches, and news now have real timeouts instead of relying on a 100 second default. The launcher logs when it finds a Steam library file that doesn't parse into anything useful, instead of that looking identical to "not installed." Two tooltip and manifest display bugs that reviewers caught got fixed: the disabled button tooltip explaining why you can't install/update is back, and a failed manifest refresh no longer silently wipes out the version list it's supposedly still showing you.

And since I was in here anyway: when the launcher finds an update for itself now, the "update found" prompt actually shows you the release notes for that version instead of just a generic "there's an update" message. Should make it obvious what you're actually installing going forward.

## Why this is one big PR

All of this landed as a stack of smaller, reviewed PRs targeting this branch, which is why the commit history looks like a proper trail rather than one giant dump. Full test suite is green throughout, every fix in here has a regression test behind it.
