### PR TITLE
Tell the user when an update's download isn't available yet

### DIFF
--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -188,7 +188,16 @@ public class UpdateService : IUpdateService
 
             if (asset == null)
             {
+                // The CI release workflow creates the GitHub release first and then uploads the
+                // (large) platform binaries as assets, so a check that lands in that window sees
+                // the new version with no matching asset yet. This used to fall through silently -
+                // the user clicked OK and nothing visibly happened until a later check re-fetched
+                // the release (reported as "won't update on first click of ok").
                 _log.Warn($"No asset matched platform keyword '{platformKeyword}' in release v{latestRelease.Version}. Available assets: {string.Join(", ", latestRelease.Release.Assets.Select(a => a.Name))}");
+                await _messageBoxService.ShowMessageBoxAsOwnedAsync("Update Not Ready Yet",
+                    $"Version {latestRelease.Version} was just published but its download isn't available yet.\nThe launcher will retry automatically in a few minutes, or you can restart it to try again.",
+                    ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+                return false;
             }
             else
             {


### PR DESCRIPTION
Fixes the "Not Updating On First Click" bug report from Discord.

The CI release workflow creates the GitHub release first and then uploads the platform binaries as assets. The launcher polls for updates every 10 minutes, so a check that lands in that upload window sees the new version but finds no matching asset for its platform. Clicking OK on the "Update Found" dialog then fell through with no feedback at all: nothing downloaded, no error, nothing. Restarting the launcher later refetched the release with its assets in place, which is why the reporter found that closing and reopening "fixed" it. This path has been silent since the first version of the update code, so every shipped build has it, including v0.2.0.

Fixed at two layers:

**Launcher:** the release is validated (platform asset present, sha256 digest present) *before* the "Update Found" dialog is shown. An incomplete release is treated as not-yet-published and skipped quietly; the next periodic check picks it up once its files are all there. The user is never prompted about an update that can't actually be installed.

**Release workflow:** the GitHub release is now created as a draft, binaries are uploaded, and only then is it flipped public. Drafts are invisible to the releases API, so the race window doesn't exist anymore at all. This part also protects every launcher already out in the wild (v0.1.1, v0.2.0), which no client-side fix can do.

Note on testing: no regression test for the client-side change, since UpdateService talks to GitHub through a raw HttpClient with no seam to mock. Worth extracting an abstraction if this service keeps growing, but that felt like too much surgery for a patch release.
