### PR TITLE
Updater v0.2.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,14 @@ jobs:
         TAG: ${{ steps.get_version.outputs.TAG }}
         TITLE: "KSP2 Redux Updater v${{ steps.get_version.outputs.VERSION }}"
       run: |
+        # Create as a draft first: launchers in the wild poll the releases API every
+        # 10 minutes, and a release that becomes visible before its binaries finish
+        # uploading gets offered as an update that can't actually be downloaded.
+        # Drafts are invisible to the API, so only flip it public once everything is up.
         gh release create "$TAG" \
           ./publish/Ksp2Redux-win-x64.exe \
           ./publish/Ksp2Redux-linux-x64 \
           --title "$TITLE" \
-          --generate-notes
+          --generate-notes \
+          --draft
+        gh release edit "$TAG" --draft=false

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.2.0</Version>
+        <Version>0.2.1</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -188,7 +188,16 @@ public class UpdateService : IUpdateService
 
             if (asset == null)
             {
+                // The CI release workflow creates the GitHub release first and then uploads the
+                // (large) platform binaries as assets, so a check that lands in that window sees
+                // the new version with no matching asset yet. This used to fall through silently -
+                // the user clicked OK and nothing visibly happened until a later check re-fetched
+                // the release (reported as "won't update on first click of ok").
                 _log.Warn($"No asset matched platform keyword '{platformKeyword}' in release v{latestRelease.Version}. Available assets: {string.Join(", ", latestRelease.Release.Assets.Select(a => a.Name))}");
+                await _messageBoxService.ShowMessageBoxAsOwnedAsync("Update Not Ready Yet",
+                    $"Version {latestRelease.Version} was just published but its download isn't available yet.\nThe launcher will retry automatically in a few minutes, or you can restart it to try again.",
+                    ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+                return false;
             }
             else
             {

--- a/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/UpdateService.cs
@@ -167,6 +167,22 @@ public class UpdateService : IUpdateService
         {
             _log.Info($"Update available: v{latestRelease.Version}.");
 
+            // Validate the release is actually installable BEFORE prompting. The CI workflow used
+            // to create the release visibly and then upload the (large) platform binaries, so a
+            // check landing in that window saw the new version with no usable asset yet - and
+            // clicking OK on the dialog silently did nothing (reported as "won't update on first
+            // click of ok"). An incomplete release is treated as not-yet-published: skip quietly
+            // and let the next periodic check pick it up once its files are all there.
+            var platformKeyword = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" : "linux";
+            var asset = latestRelease.Release.Assets
+                .FirstOrDefault(a => a.Name.Contains(platformKeyword, StringComparison.OrdinalIgnoreCase));
+            const string sha256Prefix = "sha256:";
+            if (asset == null || asset.Digest?.StartsWith(sha256Prefix, StringComparison.OrdinalIgnoreCase) != true)
+            {
+                _log.Warn($"Release v{latestRelease.Version} has no usable '{platformKeyword}' asset yet (missing asset or sha256 digest - still uploading?). Skipping until a later check. Available assets: {string.Join(", ", latestRelease.Release.Assets.Select(a => a.Name))}");
+                return true;
+            }
+
             if (!_isSingleFile)
             {
                 _log.Warn("Running in non-single-file build, refusing to self-update.");
@@ -182,86 +198,58 @@ public class UpdateService : IUpdateService
 
             if (result != ButtonResult.Ok) return false;
 
-            var platformKeyword = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" : "linux";
-            var asset = latestRelease.Release.Assets
-                .FirstOrDefault(a => a.Name.Contains(platformKeyword, StringComparison.OrdinalIgnoreCase));
+            _log.Info($"Selected update asset: {asset.Name}.");
+            var expectedHash = asset.Digest[sha256Prefix.Length..].Trim().ToLowerInvariant();
 
-            if (asset == null)
+            DownloadingChanged?.Invoke(true);
+            var restartTriggered = false;
+            try
             {
-                // The CI release workflow creates the GitHub release first and then uploads the
-                // (large) platform binaries as assets, so a check that lands in that window sees
-                // the new version with no matching asset yet. This used to fall through silently -
-                // the user clicked OK and nothing visibly happened until a later check re-fetched
-                // the release (reported as "won't update on first click of ok").
-                _log.Warn($"No asset matched platform keyword '{platformKeyword}' in release v{latestRelease.Version}. Available assets: {string.Join(", ", latestRelease.Release.Assets.Select(a => a.Name))}");
-                await _messageBoxService.ShowMessageBoxAsOwnedAsync("Update Not Ready Yet",
-                    $"Version {latestRelease.Version} was just published but its download isn't available yet.\nThe launcher will retry automatically in a few minutes, or you can restart it to try again.",
-                    ButtonEnum.Ok, windowStartupLocation: WindowStartupLocation.CenterOwner);
+                _log.Info($"Downloading {asset.Name} from {asset.BrowserDownloadUrl}.");
+                var bytes = await _http.GetByteArrayAsync(asset.BrowserDownloadUrl);
+                var actualHash = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+                if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    _log.Error($"Checksum mismatch for {asset.Name}: expected {expectedHash}, got {actualHash}");
+                    await ShowUpdateFailedAsync();
+                    return false;
+                }
+                _log.Info($"Downloaded {bytes.Length} bytes for {asset.Name}, checksum verified.");
+
+                var updateDir = _fileSystem.Path.Combine(_launcherConfigService.GetLocalStorageDirectory(), "update");
+                _fileSystem.Directory.CreateDirectory(updateDir);
+                foreach (var stale in _fileSystem.Directory.EnumerateFiles(updateDir))
+                {
+                    try { _fileSystem.File.Delete(stale); } catch { }
+                }
+
+                var updatePath = _fileSystem.Path.Combine(updateDir, asset.Name);
+                await _fileSystem.File.WriteAllBytesAsync(updatePath, bytes);
+                _log.Info($"Wrote update binary to {updatePath}. Triggering restart.");
+
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    using var chmod = Process.Start("chmod", $"+x \"{updatePath}\"")!;
+                    await chmod.WaitForExitAsync();
+                    if (chmod.ExitCode != 0)
+                    {
+                        throw new InvalidOperationException($"chmod +x on {updatePath} exited with code {chmod.ExitCode}.");
+                    }
+                }
+
+                TriggerRestart(updatePath);
+                restartTriggered = true;
+            }
+            catch (Exception e)
+            {
+                _log.Error($"Update download/install failed for {asset.Name}.", e);
+                await ShowUpdateFailedAsync();
                 return false;
             }
-            else
+            finally
             {
-                _log.Info($"Selected update asset: {asset.Name}.");
-                const string sha256Prefix = "sha256:";
-                if (asset.Digest == null || !asset.Digest.StartsWith(sha256Prefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    _log.Error($"No sha256 digest reported by GitHub for {asset.Name}, refusing to update.");
-                    await ShowUpdateFailedAsync();
-                    return false;
-                }
-
-                var expectedHash = asset.Digest[sha256Prefix.Length..].Trim().ToLowerInvariant();
-
-                DownloadingChanged?.Invoke(true);
-                var restartTriggered = false;
-                try
-                {
-                    _log.Info($"Downloading {asset.Name} from {asset.BrowserDownloadUrl}.");
-                    var bytes = await _http.GetByteArrayAsync(asset.BrowserDownloadUrl);
-                    var actualHash = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
-
-                    if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _log.Error($"Checksum mismatch for {asset.Name}: expected {expectedHash}, got {actualHash}");
-                        await ShowUpdateFailedAsync();
-                        return false;
-                    }
-                    _log.Info($"Downloaded {bytes.Length} bytes for {asset.Name}, checksum verified.");
-
-                    var updateDir = _fileSystem.Path.Combine(_launcherConfigService.GetLocalStorageDirectory(), "update");
-                    _fileSystem.Directory.CreateDirectory(updateDir);
-                    foreach (var stale in _fileSystem.Directory.EnumerateFiles(updateDir))
-                    {
-                        try { _fileSystem.File.Delete(stale); } catch { }
-                    }
-
-                    var updatePath = _fileSystem.Path.Combine(updateDir, asset.Name);
-                    await _fileSystem.File.WriteAllBytesAsync(updatePath, bytes);
-                    _log.Info($"Wrote update binary to {updatePath}. Triggering restart.");
-
-                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        using var chmod = Process.Start("chmod", $"+x \"{updatePath}\"")!;
-                        await chmod.WaitForExitAsync();
-                        if (chmod.ExitCode != 0)
-                        {
-                            throw new InvalidOperationException($"chmod +x on {updatePath} exited with code {chmod.ExitCode}.");
-                        }
-                    }
-
-                    TriggerRestart(updatePath);
-                    restartTriggered = true;
-                }
-                catch (Exception e)
-                {
-                    _log.Error($"Update download/install failed for {asset.Name}.", e);
-                    await ShowUpdateFailedAsync();
-                    return false;
-                }
-                finally
-                {
-                    if (!restartTriggered) DownloadingChanged?.Invoke(false);
-                }
+                if (!restartTriggered) DownloadingChanged?.Invoke(false);
             }
         }
         else


### PR DESCRIPTION
Patch release for the silent self-update failure reported on Discord ("Not Updating On First Click").

If the launcher's update check ran while a new release's binaries were still uploading to GitHub, it saw the new version but no download for it. Clicking OK on the "Update Found" dialog then silently did nothing, and only a restart or a later check picked the update up. This has been broken since the first version of the update code, so every shipped build is affected.

Contains:
- #45 - First pass: show an "Update Not Ready Yet" message instead of failing silently
- #47 - The actual fix: validate a release is complete before ever prompting the user, and publish GitHub releases as drafts so a half-uploaded release is never visible to launchers in the first place. That second part also protects everyone still on v0.1.1/v0.2.0.
- Version bump to 0.2.1

Draft until #47 is merged. Merging this into main triggers the release build and deploys the patch.