### PR TITLE
Make the launcher window resizable and maximizable

### DIFF
--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
@@ -4,8 +4,8 @@
         xmlns:views="using:Ksp2Redux.Tools.Launcher.Views"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="700"
-        Width="1000" Height="700" CanResize="False"
+        mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
+        Width="1280" Height="800" MinWidth="1000" MinHeight="700" CanResize="True"
         x:Class="Ksp2Redux.Tools.Launcher.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Background="Transparent"
@@ -36,6 +36,19 @@
     <!-- ReSharper restore Xaml.RedundantResource -->
 
     <Window.Styles>
+        <!-- When maximized the OS squares the window anyway, so rounded corners would
+             leave black notches at the screen edges - square everything. The red 2px
+             frame itself deliberately stays visible in every state (brand signature). -->
+        <Style Selector="Border#OuterFrame.maximized">
+            <Setter Property="CornerRadius" Value="0" />
+        </Style>
+        <Style Selector="Border#InnerChrome.maximized">
+            <Setter Property="CornerRadius" Value="0" />
+        </Style>
+        <Style Selector="Border#TitleBar.maximized">
+            <Setter Property="CornerRadius" Value="0" />
+        </Style>
+
         <Style Selector="Border#TitleBar">
             <!-- Matches the inner chrome Border's CornerRadius below (RadiusLarge minus
                  the outer frame's 2px BorderThickness) so it nests flush at the top
@@ -99,14 +112,18 @@
         </Style>
     </Window.Styles>
 
-    <Border BorderBrush="{StaticResource BrandRedBrush}" BorderThickness="2" CornerRadius="{StaticResource RadiusLarge}" VerticalAlignment="Stretch">
+    <Panel>
+    <Border Name="OuterFrame" BorderBrush="{StaticResource BrandRedBrush}" BorderThickness="2" CornerRadius="{StaticResource RadiusLarge}" VerticalAlignment="Stretch">
         <!-- 10 = RadiusLarge (12) minus the outer Border's 2px BorderThickness, so the
              two borders form a properly nested concentric ring instead of a mismatched gap. -->
-        <Border Background="Black" CornerRadius="10" ClipToBounds="True">
+        <Border Name="InnerChrome" Background="Black" CornerRadius="10" ClipToBounds="True">
             <Grid RowDefinitions="Auto,*">
                 <Border Grid.RowSpan="2">
                     <Border.Background>
-                        <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" />
+                        <!-- UniformToFill: the default Fill would distort the art once the window can be
+     any aspect ratio. All three copies (base + two blur layers) must use the same
+     stretch so the blurred copies stay pixel-aligned with the base. -->
+                        <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" Stretch="UniformToFill" />
                     </Border.Background>
                 </Border>
 
@@ -123,7 +140,7 @@
                 <Border Grid.RowSpan="2" Name="ContentBackdropBlur" IsHitTestVisible="False"
                         IsVisible="{Binding IsContentPanelVisible}">
                     <Border.Background>
-                        <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" />
+                        <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" Stretch="UniformToFill" />
                     </Border.Background>
                     <Border.Effect>
                         <BlurEffect Radius="36" />
@@ -135,7 +152,7 @@
                      binding needed here). -->
                 <Border Grid.RowSpan="2" Name="SidebarBackdropBlur" IsHitTestVisible="False">
                     <Border.Background>
-                        <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" />
+                        <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" Stretch="UniformToFill" />
                     </Border.Background>
                     <Border.Effect>
                         <BlurEffect Radius="36" />
@@ -153,7 +170,7 @@
                 </Border>
                 <Border Name="TitleBar">
                     <Grid Height="32" Background="Black" PointerPressed="TitleBar_PointerPressed"
-                          ColumnDefinitions="*,32,32">
+                          ColumnDefinitions="*,32,32,32">
                         <Button Classes="titlebar-button"
                                 Grid.Column="1"
                                 Width="32"
@@ -174,7 +191,28 @@
                                            TextAlignment="Center" />
                             </Border>
                         </Button>
-                        <Button Name="CloseButton" Classes="titlebar-button" Grid.Column="2"
+                        <Button Name="MaximizeButton" Classes="titlebar-button"
+                                Grid.Column="2"
+                                Width="32"
+                                Height="32"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                Click="Maximize_Click">
+                            <Border Classes="titlebar-button-surface"
+                                    Width="32"
+                                    Height="32"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch">
+                                <TextBlock Name="MaximizeGlyph"
+                                           Text="◻"
+                                           FontSize="13"
+                                           FontFamily="Segoe UI Symbol"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           TextAlignment="Center" />
+                            </Border>
+                        </Button>
+                        <Button Name="CloseButton" Classes="titlebar-button" Grid.Column="3"
                                 Width="32"
                                 Height="32"
                                 HorizontalAlignment="Stretch"
@@ -239,4 +277,21 @@
             </Grid>
         </Border>
     </Border>
+
+    <!-- Invisible resize grips along the window edges. With WindowDecorations="None"
+         there is no native frame to grab, and on Linux no WM-provided resize border
+         exists at all, so these are the guaranteed cross-platform resize surface.
+         Hidden while maximized (code-behind toggles IsVisible). Edges are inset by
+         12px at the ends so the corner grips win their overlap. -->
+    <Grid Name="ResizeGrips">
+        <Border Background="Transparent" Height="6" VerticalAlignment="Top" Margin="12,0" Cursor="TopSide" Tag="North" PointerPressed="ResizeGrip_PointerPressed" />
+        <Border Background="Transparent" Height="6" VerticalAlignment="Bottom" Margin="12,0" Cursor="BottomSide" Tag="South" PointerPressed="ResizeGrip_PointerPressed" />
+        <Border Background="Transparent" Width="6" HorizontalAlignment="Left" Margin="0,12" Cursor="LeftSide" Tag="West" PointerPressed="ResizeGrip_PointerPressed" />
+        <Border Background="Transparent" Width="6" HorizontalAlignment="Right" Margin="0,12" Cursor="RightSide" Tag="East" PointerPressed="ResizeGrip_PointerPressed" />
+        <Border Background="Transparent" Width="12" Height="12" HorizontalAlignment="Left" VerticalAlignment="Top" Cursor="TopLeftCorner" Tag="NorthWest" PointerPressed="ResizeGrip_PointerPressed" />
+        <Border Background="Transparent" Width="12" Height="12" HorizontalAlignment="Right" VerticalAlignment="Top" Cursor="TopRightCorner" Tag="NorthEast" PointerPressed="ResizeGrip_PointerPressed" />
+        <Border Background="Transparent" Width="12" Height="12" HorizontalAlignment="Left" VerticalAlignment="Bottom" Cursor="BottomLeftCorner" Tag="SouthWest" PointerPressed="ResizeGrip_PointerPressed" />
+        <Border Background="Transparent" Width="12" Height="12" HorizontalAlignment="Right" VerticalAlignment="Bottom" Cursor="BottomRightCorner" Tag="SouthEast" PointerPressed="ResizeGrip_PointerPressed" />
+    </Grid>
+    </Panel>
 </Window>

--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
@@ -23,9 +23,8 @@ public partial class MainWindow : Window
         InitializeComponent();
         Opened += (_, _) =>
         {
-            DisableWindowResize();
             ApplyNativeRoundedCorners();
-            SetCustomWndProc();
+            UpdateMaximizedState();
             RefreshBackdropClips();
         };
 
@@ -34,6 +33,29 @@ public partial class MainWindow : Window
         // we can hook. Recomputing on every layout pass keeps it in sync regardless of
         // what caused the layout change.
         LayoutUpdated += (_, _) => RefreshBackdropClips();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == WindowStateProperty)
+        {
+            UpdateMaximizedState();
+        }
+    }
+
+    // The red 2px frame deliberately stays in every state (brand signature); only the
+    // corner rounding drops at maximize, since the OS squares the window anyway and a
+    // rounded clip would leave black notches at the screen edges.
+    private void UpdateMaximizedState()
+    {
+        var maximized = WindowState == WindowState.Maximized;
+        OuterFrame?.Classes.Set("maximized", maximized);
+        InnerChrome?.Classes.Set("maximized", maximized);
+        this.FindControl<Border>("TitleBar")?.Classes.Set("maximized", maximized);
+        if (ResizeGrips is not null) ResizeGrips.IsVisible = !maximized;
+        if (MaximizeGlyph is not null) MaximizeGlyph.Text = maximized ? "❐" : "◻";
+        if (MaximizeButton is not null) ToolTip.SetTip(MaximizeButton, maximized ? "Restore" : "Maximize");
     }
 
     private void RefreshBackdropClips()
@@ -95,10 +117,22 @@ public partial class MainWindow : Window
 
     private void TitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+
+        if (e.ClickCount == 2)
         {
-            BeginMoveDrag(e);
+            ToggleMaximized();
+            return;
         }
+
+        BeginMoveDrag(e);
+    }
+
+    private void ResizeGrip_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+        if (sender is not Control { Tag: string tag } || !Enum.TryParse<WindowEdge>(tag, out var edge)) return;
+        BeginResizeDrag(edge, e);
     }
 
     private void Minimize_Click(object? sender, RoutedEventArgs e)
@@ -106,55 +140,19 @@ public partial class MainWindow : Window
         WindowState = WindowState.Minimized;
     }
 
+    private void Maximize_Click(object? sender, RoutedEventArgs e)
+    {
+        ToggleMaximized();
+    }
+
+    private void ToggleMaximized()
+    {
+        WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+    }
+
     private void Close_Click(object? sender, RoutedEventArgs e)
     {
         Close();
-    }
-
-    private void DisableWindowResize()
-    {
-        IPlatformHandle? handle = TryGetPlatformHandle();
-        if (handle is null || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return;
-        }
-
-        const int GWL_STYLE = -16;
-        const int WS_THICKFRAME = 0x00040000;
-        const uint SWP_NOMOVE = 0x0002;
-        const uint SWP_NOSIZE = 0x0001;
-        const uint SWP_NOZORDER = 0x0004;
-        const uint SWP_NOACTIVATE = 0x0010;
-        const uint SWP_FRAMECHANGED = 0x0020;
-
-        nint hwnd = handle.Handle;
-        int style = GetWindowLong(hwnd, GWL_STYLE);
-
-        // Remove resizing
-        style &= ~WS_THICKFRAME;
-
-        SetWindowLong(hwnd, GWL_STYLE, style);
-
-        // SetWindowLong alone doesn't make Windows recompute the frame; without this,
-        // it can keep using metrics cached under the old WS_THICKFRAME style.
-        SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0,
-            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-    }
-
-    private void SetCustomWndProc()
-    {
-        IPlatformHandle? handle = TryGetPlatformHandle();
-        if (handle is null || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return;
-        }
-
-        IntPtr hwnd = handle.Handle;
-        _originalWndProc = GetWindowLongPtr(hwnd, GWLP_WNDPROC);
-        _hwnd = hwnd;
-
-        // replace WndProc with a custom one
-        SetWindowLongPtr(hwnd, GWLP_WNDPROC, Marshal.GetFunctionPointerForDelegate(NewWndProcDelegate));
     }
 
     private void ApplyNativeRoundedCorners()
@@ -180,42 +178,7 @@ public partial class MainWindow : Window
         }
     }
 
-    private delegate nint WndProcDelegate(nint hWnd, uint msg, nint wParam, nint lParam);
-    private static nint _originalWndProc;
-    private static nint _hwnd;
-    private static readonly WndProcDelegate NewWndProcDelegate = CustomWndProc;
     private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
-
-    private static nint CustomWndProc(nint hWnd, uint msg, nint wParam, nint lParam)
-    {
-        const uint WM_NCHITTEST = 0x0084;
-        const int HTCLIENT = 1;
-
-        return msg == WM_NCHITTEST
-            ? HTCLIENT // Always return client area — no resize zones
-            : CallWindowProc(_originalWndProc, hWnd, msg, wParam, lParam); // Call original WndProc for everything else
-    }
-
-    // Win32 interop
-    private const int GWLP_WNDPROC = -4;
-
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern int GetWindowLong(nint hWnd, int nIndex);
-
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern int SetWindowLong(nint hWnd, int nIndex, int dwNewLong);
-
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
-
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
-
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint newProc);
-
-    [DllImport("user32.dll")]
-    private static extern nint CallWindowProc(nint lpPrevWndFunc, nint hWnd, uint msg, nint wParam, nint lParam);
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(nint hwnd, int attribute, ref int pvAttribute, int cbAttribute);


### PR DESCRIPTION
Stage 1 of the v0.3.0 redesign: the window infrastructure, no layout changes yet.

The window was locked at 1000x700 three separate ways: CanResize=False, a Win32 call stripping WS_THICKFRAME on open, and a custom WndProc answering HTCLIENT to every hit-test so no resize zones existed anywhere. All three are removed. Avalonia keeps WS_THICKFRAME on its own now, which also restores Aero Snap and Win+Arrow handling for free. The DWM rounded-corner call is untouched.

What's new:
- Default 1280x800, minimum 1000x700 (the current layout is the floor, nothing can underflow it)
- Maximize button in the title bar, plus double-click on the title bar to toggle
- Invisible resize grips along the edges/corners. With decorations off there is no native frame to grab, and on Linux no WM resize border exists at all, so the grips are the guaranteed cross-platform resize surface
- When maximized, corners square off (the OS squares the window anyway, keeping the rounding would leave black notches at the screen edges) but the red 2px frame stays visible in every state
- Background art switches to UniformToFill on all three copies (base + both blur layers, which have to match to stay pixel-aligned) so arbitrary aspect ratios don't distort it