### PR TITLE
Remember the window's size and position between runs

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/TestAppBuilder.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/TestAppBuilder.cs
@@ -87,6 +87,7 @@ public static class TestAppBuilder
         serviceCollection.AddSingleton(MessageBoxService.Object); 
         serviceCollection.AddSingleton(OperatingSystemService.Object);
         serviceCollection.AddSingleton(DiskSpaceService.Object);
+        serviceCollection.AddSingleton<IWindowPlacementService, WindowPlacementService>();
         ServiceProvider = serviceCollection.BuildServiceProvider();
     }
 }

--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/WindowPlacementPersistenceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/WindowPlacementPersistenceTest.cs
@@ -1,0 +1,47 @@
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.Services;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class WindowPlacementPersistenceTest
+{
+    [AvaloniaTest]
+    public void ClosingTheWindow_PersistsItsPlacementToTheConfig()
+    {
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        var configService = TestAppBuilder.ServiceProvider.GetRequiredService<ILauncherConfigService>();
+        Assert.That(configService.Config.WindowPlacement, Is.Null, "Fresh config must start without a placement.");
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.Width = 1400;
+        window.Height = 900;
+        Dispatcher.UIThread.RunJobs();
+        window.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        var saved = configService.Config.WindowPlacement;
+        Assert.Multiple(() =>
+        {
+            Assert.That(saved, Is.Not.Null, "Closing must write the placement to the config.");
+            Assert.That(saved!.Width, Is.EqualTo(1400));
+            Assert.That(saved.Height, Is.EqualTo(900));
+            Assert.That(saved.IsMaximized, Is.False);
+        });
+    }
+}

--- a/Ksp2Redux.Tools.Launcher.Test/WindowPlacementServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/WindowPlacementServiceTest.cs
@@ -1,0 +1,115 @@
+using Avalonia;
+using Ksp2Redux.Tools.Launcher.Models;
+using Ksp2Redux.Tools.Launcher.Services;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class WindowPlacementServiceTest
+{
+    private static readonly PixelRect PrimaryScreen = new(0, 0, 2560, 1400);
+    private static readonly PixelRect SecondScreen = new(2560, 0, 2560, 1400);
+    private readonly WindowPlacementService _service = new();
+
+    [Test]
+    public void NullPlacement_ReturnsNull()
+    {
+        Assert.That(_service.Sanitize(null, [PrimaryScreen], 1000, 700), Is.Null);
+    }
+
+    [Test]
+    public void OnScreenPlacement_IsReturnedUnchanged()
+    {
+        var saved = new WindowPlacement { X = 100, Y = 100, Width = 1280, Height = 800, IsMaximized = false };
+
+        var result = _service.Sanitize(saved, [PrimaryScreen], 1000, 700);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result!.X, Is.EqualTo(100));
+            Assert.That(result.Y, Is.EqualTo(100));
+            Assert.That(result.Width, Is.EqualTo(1280));
+            Assert.That(result.Height, Is.EqualTo(800));
+        });
+    }
+
+    [Test]
+    public void PlacementOnAMonitorThatNoLongerExists_IsNudgedOntoTheNearestScreen()
+    {
+        // Saved while a second monitor was attached; only the primary remains.
+        var saved = new WindowPlacement { X = 3000, Y = 200, Width = 1280, Height = 800 };
+
+        var result = _service.Sanitize(saved, [PrimaryScreen], 1000, 700);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result!.X, Is.LessThanOrEqualTo(PrimaryScreen.Right - 1280));
+            Assert.That(result.X, Is.GreaterThanOrEqualTo(PrimaryScreen.X));
+            Assert.That(result.Y, Is.EqualTo(200), "Y was already fine and should not move.");
+            Assert.That(result.Width, Is.EqualTo(1280), "The user's chosen size must survive the nudge.");
+        });
+    }
+
+    [Test]
+    public void PlacementStillOnTheSecondMonitor_IsLeftAloneWhenThatMonitorExists()
+    {
+        var saved = new WindowPlacement { X = 3000, Y = 200, Width = 1280, Height = 800 };
+
+        var result = _service.Sanitize(saved, [PrimaryScreen, SecondScreen], 1000, 700);
+
+        Assert.That(result!.X, Is.EqualTo(3000));
+    }
+
+    [Test]
+    public void SizeBelowTheMinimum_IsRaisedToTheMinimum()
+    {
+        var saved = new WindowPlacement { X = 100, Y = 100, Width = 640, Height = 480 };
+
+        var result = _service.Sanitize(saved, [PrimaryScreen], 1000, 700);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result!.Width, Is.EqualTo(1000));
+            Assert.That(result.Height, Is.EqualTo(700));
+        });
+    }
+
+    [TestCase(double.NaN, 800)]
+    [TestCase(1280, double.PositiveInfinity)]
+    [TestCase(0, 800)]
+    [TestCase(-500, 800)]
+    public void GarbageDimensions_ReturnNullSoDefaultsApply(double width, double height)
+    {
+        var saved = new WindowPlacement { X = 100, Y = 100, Width = width, Height = height };
+
+        Assert.That(_service.Sanitize(saved, [PrimaryScreen], 1000, 700), Is.Null);
+    }
+
+    [Test]
+    public void NoScreenInformation_ReturnsThePlacementWithoutValidation()
+    {
+        var saved = new WindowPlacement { X = 100, Y = 100, Width = 1280, Height = 800 };
+
+        var result = _service.Sanitize(saved, [], 1000, 700);
+
+        Assert.That(result!.X, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void WindowAboveTheVisibleArea_IsPulledDownSoTheTitleBarIsGrabbable()
+    {
+        // Title bar way above the top edge of every screen - nothing to grab and drag.
+        var saved = new WindowPlacement { X = 100, Y = -2000, Width = 1280, Height = 800 };
+
+        var result = _service.Sanitize(saved, [PrimaryScreen], 1000, 700);
+
+        Assert.That(result!.Y, Is.GreaterThanOrEqualTo(PrimaryScreen.Y));
+    }
+
+    [Test]
+    public void MaximizedFlag_IsPreserved()
+    {
+        var saved = new WindowPlacement { X = 100, Y = 100, Width = 1280, Height = 800, IsMaximized = true };
+
+        Assert.That(_service.Sanitize(saved, [PrimaryScreen], 1000, 700)!.IsMaximized, Is.True);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/DefaultServiceProviderProvider.cs
+++ b/Ksp2Redux.Tools.Launcher/DefaultServiceProviderProvider.cs
@@ -43,6 +43,7 @@ public static class DefaultServiceProviderProvider
         serviceCollection.AddSingleton<IMessageBoxService, MessageBoxService>();
         serviceCollection.AddSingleton<IOperatingSystemService, OperatingSystemService>();
         serviceCollection.AddSingleton<IDiskSpaceService, DiskSpaceService>();
+        serviceCollection.AddSingleton<IWindowPlacementService, WindowPlacementService>();
         return serviceCollection.BuildServiceProvider();
     }
 }

--- a/Ksp2Redux.Tools.Launcher/Models/LauncherConfig.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/LauncherConfig.cs
@@ -34,6 +34,12 @@ public class LauncherConfig
     /// </summary>
     public bool VerboseLogging { get; set; } = false;
 
+    /// <summary>
+    /// Last window geometry. Null until the window has been closed once (first run
+    /// uses the built-in defaults and centers on screen).
+    /// </summary>
+    public WindowPlacement? WindowPlacement { get; set; }
+
     [JsonIgnore]
     public string StoragePath { get; set; }
 

--- a/Ksp2Redux.Tools.Launcher/Models/WindowPlacement.cs
+++ b/Ksp2Redux.Tools.Launcher/Models/WindowPlacement.cs
@@ -1,0 +1,16 @@
+namespace Ksp2Redux.Tools.Launcher.Models;
+
+/// <summary>
+/// Persisted window geometry. X/Y are physical screen pixels (Avalonia's Window.Position),
+/// Width/Height are logical units (Window.Width/Height) - the mix mirrors what Avalonia
+/// itself exposes. When the window closes maximized, Width/Height/X/Y hold the last
+/// NORMAL bounds so a restore-from-maximized lands where the user left the window.
+/// </summary>
+public class WindowPlacement
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+    public bool IsMaximized { get; set; }
+}

--- a/Ksp2Redux.Tools.Launcher/Services/WindowPlacementService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/WindowPlacementService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Ksp2Redux.Tools.Launcher.Models;
+
+namespace Ksp2Redux.Tools.Launcher.Services;
+
+public interface IWindowPlacementService
+{
+    /// <summary>
+    /// Validates a saved placement against the CURRENT monitor layout and returns a safe
+    /// one to apply, or null when there's nothing usable and the caller should fall back
+    /// to the built-in defaults (CenterScreen). Monitors get unplugged and resolutions
+    /// change between runs, so the saved values can't be trusted blindly - a window
+    /// restored onto a screen that no longer exists would be unreachable.
+    /// </summary>
+    WindowPlacement? Sanitize(WindowPlacement? saved, IReadOnlyList<PixelRect> screenWorkingAreas, double minWidth, double minHeight);
+}
+
+public class WindowPlacementService : IWindowPlacementService
+{
+    // How much of the title-bar strip must remain on some screen for the window to count
+    // as grabbable. Generous on purpose: the goal is only to prevent a stranded window,
+    // not to force it fully on-screen (half-off-screen is a legitimate user choice).
+    private const int MinVisiblePx = 48;
+
+    public WindowPlacement? Sanitize(WindowPlacement? saved, IReadOnlyList<PixelRect> screenWorkingAreas, double minWidth, double minHeight)
+    {
+        if (saved is null) return null;
+        if (!IsSane(saved.Width) || !IsSane(saved.Height)) return null;
+
+        var result = new WindowPlacement
+        {
+            X = saved.X,
+            Y = saved.Y,
+            Width = Math.Max(saved.Width, minWidth),
+            Height = Math.Max(saved.Height, minHeight),
+            IsMaximized = saved.IsMaximized,
+        };
+
+        // No screen info available (headless, exotic platform): nothing to validate against.
+        if (screenWorkingAreas.Count == 0) return result;
+
+        // The size is logical units and the areas are physical pixels, so on scaled
+        // displays this rect is an approximation - fine for a "did the monitor
+        // disappear?" check, which only needs to be roughly right.
+        var window = new PixelRect(result.X, result.Y, (int)result.Width, (int)result.Height);
+        var titleStrip = new PixelRect(window.X, window.Y, window.Width, MinVisiblePx);
+
+        var grabbable = screenWorkingAreas.Any(area =>
+        {
+            var overlap = area.Intersect(titleStrip);
+            return overlap.Width >= MinVisiblePx && overlap.Height >= Math.Min(MinVisiblePx, titleStrip.Height);
+        });
+        if (grabbable) return result;
+
+        // The saved spot no longer exists (monitor unplugged, resolution shrank). Nudge
+        // the window into the nearest working area rather than discarding the size the
+        // user chose.
+        var nearest = screenWorkingAreas
+            .OrderBy(area => Distance(area, window))
+            .First();
+        result.X = Math.Clamp(window.X, nearest.X, Math.Max(nearest.X, nearest.Right - window.Width));
+        result.Y = Math.Clamp(window.Y, nearest.Y, Math.Max(nearest.Y, nearest.Bottom - MinVisiblePx));
+        return result;
+    }
+
+    private static bool IsSane(double dimension) =>
+        double.IsFinite(dimension) && dimension > 0 && dimension < 100_000;
+
+    private static double Distance(PixelRect area, PixelRect window)
+    {
+        var dx = Math.Max(0, Math.Max(area.X - window.Right, window.X - area.Right));
+        var dy = Math.Max(0, Math.Max(area.Y - window.Bottom, window.Y - area.Bottom));
+        return dx * dx + (double)dy * dy;
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -36,6 +36,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IKsp2DetectorService _ksp2DetectorService;
     private readonly IKsp2InstallService _ksp2InstallService;
     private readonly IMessageBoxService _messageBoxService;
+    private readonly IWindowPlacementService _windowPlacementService;
     private readonly ILogService _log;
 
     [ObservableProperty]
@@ -65,10 +66,11 @@ public partial class MainWindowViewModel : ViewModelBase
         INewsItemCollectionService newsCollectionService, ILauncherConfigService launcherConfigService,
         IReleasesFeedService releasesFeedService, ITabNavigatorService tabNavigatorService, IFileSystem fileSystem,
         INewsService newsService, IManifestReleasesFeedProviderService manifestReleasesFeedProviderService, IUpdateService updateService,
-        IKsp2DetectorService ksp2DetectorService, IMessageBoxService messageBoxService, ILogService log)
+        IKsp2DetectorService ksp2DetectorService, IMessageBoxService messageBoxService, IWindowPlacementService windowPlacementService, ILogService log)
     {
         _newsCollectionService = newsCollectionService;
         _launcherConfigService = launcherConfigService;
+        _windowPlacementService = windowPlacementService;
         _releasesFeedService = releasesFeedService;
         _tabNavigatorService = tabNavigatorService;
         _fileSystem = fileSystem;
@@ -151,6 +153,19 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             _log.Error("Background task faulted.", antecedent.Exception);
         }
+    }
+
+    /// <summary>
+    /// Returns the placement the window should restore to, validated against the current
+    /// monitor layout, or null to use the built-in defaults (first run, or garbage data).
+    /// </summary>
+    public WindowPlacement? GetRestoredWindowPlacement(IReadOnlyList<Avalonia.PixelRect> screenWorkingAreas, double minWidth, double minHeight) =>
+        _windowPlacementService.Sanitize(_launcherConfigService.Config.WindowPlacement, screenWorkingAreas, minWidth, minHeight);
+
+    public void SaveWindowPlacement(WindowPlacement placement)
+    {
+        _launcherConfigService.Config.WindowPlacement = placement;
+        _launcherConfigService.Save();
     }
 
     public Task LaunchExternalLinkAsync(TopLevel? topLevel, string url)

--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
@@ -6,6 +7,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform;
+using Ksp2Redux.Tools.Launcher.Models;
 using Ksp2Redux.Tools.Launcher.ViewModels;
 
 namespace Ksp2Redux.Tools.Launcher.Views;
@@ -24,9 +26,15 @@ public partial class MainWindow : Window
         Opened += (_, _) =>
         {
             ApplyNativeRoundedCorners();
+            RestoreWindowPlacement();
             UpdateMaximizedState();
             RefreshBackdropClips();
         };
+        PositionChanged += (_, e) =>
+        {
+            if (WindowState == WindowState.Normal) _lastNormalPosition = e.Point;
+        };
+        Closing += (_, _) => SaveWindowPlacement();
 
         // Which panel is "active" changes on every tab switch and every time Home's log
         // or Community's article shows/hides, none of which fire a single one-shot event
@@ -42,6 +50,53 @@ public partial class MainWindow : Window
         {
             UpdateMaximizedState();
         }
+        else if (change.Property == ClientSizeProperty && WindowState == WindowState.Normal)
+        {
+            _lastNormalSize = ClientSize;
+        }
+    }
+
+    // The size/position to persist must be the NORMAL bounds even when the window closes
+    // maximized or minimized - saving the maximized rect would make restore-from-maximized
+    // snap to a full-screen-sized "normal" window.
+    private PixelPoint _lastNormalPosition;
+    private Size _lastNormalSize;
+
+    private void RestoreWindowPlacement()
+    {
+        _lastNormalPosition = Position;
+        _lastNormalSize = ClientSize;
+
+        if (DataContext is not MainWindowViewModel vm) return;
+        var workingAreas = Screens.All.Select(s => s.WorkingArea).ToList();
+        var placement = vm.GetRestoredWindowPlacement(workingAreas, MinWidth, MinHeight);
+        if (placement is null) return;
+
+        Position = new PixelPoint(placement.X, placement.Y);
+        Width = placement.Width;
+        Height = placement.Height;
+        _lastNormalPosition = Position;
+        _lastNormalSize = new Size(placement.Width, placement.Height);
+        if (placement.IsMaximized)
+        {
+            WindowState = WindowState.Maximized;
+        }
+    }
+
+    private void SaveWindowPlacement()
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        var normal = WindowState == WindowState.Normal;
+        var position = normal ? Position : _lastNormalPosition;
+        var size = normal ? ClientSize : _lastNormalSize;
+        vm.SaveWindowPlacement(new WindowPlacement
+        {
+            X = position.X,
+            Y = position.Y,
+            Width = size.Width,
+            Height = size.Height,
+            IsMaximized = WindowState == WindowState.Maximized,
+        });
     }
 
     // The red 2px frame deliberately stays in every state (brand signature); only the


### PR DESCRIPTION
Stage 2 of the v0.3.0 redesign, stacked on #48.

Now that the window is resizable, closing it shouldn't throw away the geometry the user picked. Placement (position, size, maximized flag) saves to the launcher config on close and restores on open.

Saved values can't be trusted blindly across runs since monitors get unplugged and resolutions change, so a new WindowPlacementService validates against the current screen layout first: a window whose title bar is no longer grabbable gets nudged onto the nearest screen (keeping its size), garbage dimensions fall back to defaults, and sizes below the minimum get raised to it. Closing while maximized saves the last NORMAL bounds, so restore-from-maximized lands where the window actually was.

13 new tests (12 unit tests on the clamping logic, one headless test proving close writes the config). Full suite green at 150/150.

NOTE FOR MERGING: this stack targets the branch below it, not updater-v0.3.0 directly. Merge #48 into updater-v0.3.0 first, then retarget this PR to updater-v0.3.0 before merging it (or just merge top-down and let GitHub auto-retarget when #48's branch is deleted).