### PR TITLE
Move the tab navigation into the title bar and add a status bar

### DIFF
--- a/Ksp2Redux.Tools.Launcher/Controls/TabControl.axaml
+++ b/Ksp2Redux.Tools.Launcher/Controls/TabControl.axaml
@@ -32,8 +32,13 @@
                 HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                 VerticalAlignment="{TemplateBinding VerticalAlignment}">
           <DockPanel LastChildFill="True">
+            <!-- The tab strip lives in the window's title bar now (MainWindow.axaml nav
+                 buttons bound to GoToTabCommand); this TabControl is only the content
+                 host, so its own header is hidden rather than removed - TabItems still
+                 carry the tab identity and selection state. -->
             <ItemsPresenter Name="PART_ItemsPresenter"
                             DockPanel.Dock="Top"
+                            IsVisible="False"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Center"
                             Margin="0,16,0,0"

--- a/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/MainWindowViewModel.cs
@@ -37,7 +37,11 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IKsp2InstallService _ksp2InstallService;
     private readonly IMessageBoxService _messageBoxService;
     private readonly IWindowPlacementService _windowPlacementService;
+    private readonly IAssemblyService _assemblyService;
     private readonly ILogService _log;
+
+    /// <summary>Launcher version shown in the title bar, e.g. "v0.3.0".</summary>
+    public string LauncherVersionText => $"v{_assemblyService.GetVersion()?.ToString(3) ?? "dev"}";
 
     [ObservableProperty]
     public partial InstallState CurrentInstallState { get; set; }
@@ -66,11 +70,13 @@ public partial class MainWindowViewModel : ViewModelBase
         INewsItemCollectionService newsCollectionService, ILauncherConfigService launcherConfigService,
         IReleasesFeedService releasesFeedService, ITabNavigatorService tabNavigatorService, IFileSystem fileSystem,
         INewsService newsService, IManifestReleasesFeedProviderService manifestReleasesFeedProviderService, IUpdateService updateService,
-        IKsp2DetectorService ksp2DetectorService, IMessageBoxService messageBoxService, IWindowPlacementService windowPlacementService, ILogService log)
+        IKsp2DetectorService ksp2DetectorService, IMessageBoxService messageBoxService, IWindowPlacementService windowPlacementService,
+        IAssemblyService assemblyService, ILogService log)
     {
         _newsCollectionService = newsCollectionService;
         _launcherConfigService = launcherConfigService;
         _windowPlacementService = windowPlacementService;
+        _assemblyService = assemblyService;
         _releasesFeedService = releasesFeedService;
         _tabNavigatorService = tabNavigatorService;
         _fileSystem = fileSystem;

--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml
@@ -49,6 +49,48 @@
             <Setter Property="CornerRadius" Value="0" />
         </Style>
 
+        <!-- Title-bar nav tabs: text buttons bound to GoToTabCommand. The "active" class
+             (toggled from code-behind when CurrentTab changes) lights the label up white
+             and shows the red underline. -->
+        <Style Selector="Button.nav-tab">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="12,0" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+            <Setter Property="CornerRadius" Value="0" />
+            <Setter Property="FontFamily" Value="{StaticResource JetBrainsMonoBold}" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}" />
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Background" Value="Transparent" />
+            </Style>
+            <Style Selector="^:pointerover">
+                <Setter Property="Foreground" Value="{StaticResource TextMutedBrush}" />
+                <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Foreground" Value="{StaticResource TextMutedBrush}" />
+                </Style>
+            </Style>
+            <Style Selector="^ Border.nav-underline">
+                <Setter Property="Background" Value="Transparent" />
+            </Style>
+            <Style Selector="^ Rectangle.tint">
+                <Setter Property="Fill" Value="{StaticResource TextSecondaryBrush}" />
+            </Style>
+        </Style>
+        <Style Selector="Button.nav-tab.active">
+            <Setter Property="Foreground" Value="White" />
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="White" />
+            </Style>
+            <Style Selector="^ Border.nav-underline">
+                <Setter Property="Background" Value="{StaticResource BrandRedBrush}" />
+            </Style>
+            <Style Selector="^ Rectangle.tint">
+                <Setter Property="Fill" Value="White" />
+            </Style>
+        </Style>
+
         <Style Selector="Border#TitleBar">
             <!-- Matches the inner chrome Border's CornerRadius below (RadiusLarge minus
                  the outer frame's 2px BorderThickness) so it nests flush at the top
@@ -117,8 +159,8 @@
         <!-- 10 = RadiusLarge (12) minus the outer Border's 2px BorderThickness, so the
              two borders form a properly nested concentric ring instead of a mismatched gap. -->
         <Border Name="InnerChrome" Background="Black" CornerRadius="10" ClipToBounds="True">
-            <Grid RowDefinitions="Auto,*">
-                <Border Grid.RowSpan="2">
+            <Grid RowDefinitions="Auto,*,Auto">
+                <Border Grid.RowSpan="3">
                     <Border.Background>
                         <!-- UniformToFill: the default Fill would distort the art once the window can be
      any aspect ratio. All three copies (base + two blur layers) must use the same
@@ -137,7 +179,7 @@
                     know where to cut. The panels themselves are then translucent instead of
                     solid so this shows through.
                 -->
-                <Border Grid.RowSpan="2" Name="ContentBackdropBlur" IsHitTestVisible="False"
+                <Border Grid.RowSpan="3" Name="ContentBackdropBlur" IsHitTestVisible="False"
                         IsVisible="{Binding IsContentPanelVisible}">
                     <Border.Background>
                         <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" Stretch="UniformToFill" />
@@ -150,7 +192,7 @@
                 <!-- Same trick as ContentBackdropBlur above, but clipped to the sidebar's
                      news panel instead, which is always shown (no IsContentPanelVisible
                      binding needed here). -->
-                <Border Grid.RowSpan="2" Name="SidebarBackdropBlur" IsHitTestVisible="False">
+                <Border Grid.RowSpan="3" Name="SidebarBackdropBlur" IsHitTestVisible="False">
                     <Border.Background>
                         <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/background.png" Stretch="UniformToFill" />
                     </Border.Background>
@@ -159,7 +201,7 @@
                     </Border.Effect>
                 </Border>
 
-                <Border Grid.RowSpan="2">
+                <Border Grid.RowSpan="3">
                     <Border.Background>
                         <LinearGradientBrush Opacity="{Binding CurrentTab, Converter={StaticResource IsSettingsTabConverter}}"
                                              StartPoint="0%,50%" EndPoint="100%,50%">
@@ -169,10 +211,59 @@
                     </Border.Background>
                 </Border>
                 <Border Name="TitleBar">
-                    <Grid Height="32" Background="Black" PointerPressed="TitleBar_PointerPressed"
-                          ColumnDefinitions="*,32,32,32">
+                    <Grid Height="40" Background="Black" PointerPressed="TitleBar_PointerPressed"
+                          ColumnDefinitions="*,Auto,*">
+                        <TextBlock Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Margin="16,0,0,0"
+                                   FontFamily="{StaticResource JetBrainsMonoRegular}"
+                                   FontSize="10"
+                                   LetterSpacing="1.5"
+                                   IsHitTestVisible="False">
+                            <Run Text="KSP2 REDUX LAUNCHER" Foreground="{StaticResource TextSecondaryBrush}" />
+                            <Run Text="{Binding LauncherVersionText}" Foreground="{StaticResource BrandRedBrush}" />
+                        </TextBlock>
+
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Stretch">
+                            <Button Name="HomeNavButton" Classes="nav-tab"
+                                    Command="{Binding GoToTabCommand}" CommandParameter="0">
+                                <StackPanel VerticalAlignment="Center" Spacing="3">
+                                    <TextBlock Text="HOME" LetterSpacing="2" />
+                                    <Border Classes="nav-underline" Height="2" />
+                                </StackPanel>
+                            </Button>
+                            <Button Name="CommunityNavButton" Classes="nav-tab"
+                                    Command="{Binding GoToTabCommand}" CommandParameter="1">
+                                <StackPanel VerticalAlignment="Center" Spacing="3">
+                                    <TextBlock Text="COMMUNITY" LetterSpacing="2" />
+                                    <Border Classes="nav-underline" Height="2" />
+                                </StackPanel>
+                            </Button>
+                            <Button Name="ModsNavButton" Classes="nav-tab"
+                                    Command="{Binding GoToTabCommand}" CommandParameter="2">
+                                <StackPanel VerticalAlignment="Center" Spacing="3">
+                                    <TextBlock Text="MODS" LetterSpacing="2" />
+                                    <Border Classes="nav-underline" Height="2" />
+                                </StackPanel>
+                            </Button>
+                            <Button Name="SettingsNavButton" Classes="nav-tab"
+                                    Command="{Binding GoToTabCommand}" CommandParameter="3"
+                                    ToolTip.Tip="Settings">
+                                <StackPanel VerticalAlignment="Center" Spacing="3">
+                                    <Canvas Width="16" Height="16">
+                                        <Rectangle Classes="tint" Width="16" Height="16" Canvas.Left="0" Canvas.Top="0">
+                                            <Rectangle.OpacityMask>
+                                                <ImageBrush Source="avares://Ksp2Redux.Tools.Launcher/Assets/settings-icon.png" />
+                                            </Rectangle.OpacityMask>
+                                        </Rectangle>
+                                    </Canvas>
+                                    <Border Classes="nav-underline" Height="2" />
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Button Classes="titlebar-button"
-                                Grid.Column="1"
                                 Width="32"
                                 Height="32"
                                 HorizontalAlignment="Stretch"
@@ -192,7 +283,6 @@
                             </Border>
                         </Button>
                         <Button Name="MaximizeButton" Classes="titlebar-button"
-                                Grid.Column="2"
                                 Width="32"
                                 Height="32"
                                 HorizontalAlignment="Stretch"
@@ -212,7 +302,7 @@
                                            TextAlignment="Center" />
                             </Border>
                         </Button>
-                        <Button Name="CloseButton" Classes="titlebar-button" Grid.Column="3"
+                        <Button Name="CloseButton" Classes="titlebar-button"
                                 Width="32"
                                 Height="32"
                                 HorizontalAlignment="Stretch"
@@ -231,6 +321,7 @@
                                            TextAlignment="Center" />
                             </Border>
                         </Button>
+                        </StackPanel>
                     </Grid>
                 </Border>
 
@@ -268,7 +359,29 @@
                     </Border>
                 </Grid>
 
-                <Border Grid.RowSpan="2" IsVisible="{Binding IsUpdateDownloading}" Background="{StaticResource ScrimMediumBrush}">
+                <!-- Thin status strip along the very bottom, per the v0.3.0 design. Mirrors
+                     the launcher-update banner state so it's visible from every tab, not
+                     just Home. -->
+                <Border Grid.Row="2" Name="StatusBar" Background="Black" Height="24">
+                    <Grid ColumnDefinitions="*,Auto" Margin="16,0">
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center"
+                                   FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="10" LetterSpacing="1"
+                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                   IsVisible="{Binding HomeTab.InstallationDisabled, Converter={StaticResource InverseBoolConverter}}"
+                                   Text="READY" />
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center"
+                                   FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="10" LetterSpacing="1"
+                                   Foreground="{StaticResource BrandRedBrush}"
+                                   IsVisible="{Binding HomeTab.InstallationDisabled}"
+                                   Text="LAUNCHER UPDATE REQUIRED - INSTALL IT FROM THE HOME TAB" />
+                        <TextBlock Grid.Column="1" VerticalAlignment="Center"
+                                   FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="10" LetterSpacing="1"
+                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                   Text="{Binding HomeTab.SelectedInstall.Name, FallbackValue=''}" />
+                    </Grid>
+                </Border>
+
+                <Border Grid.RowSpan="3" IsVisible="{Binding IsUpdateDownloading}" Background="{StaticResource ScrimMediumBrush}">
                     <TextBlock Text="Update Downloading..."
                                Foreground="{StaticResource TextPrimaryBrush}" FontSize="32"
                                FontFamily="{StaticResource JetBrainsMonoLight}"

--- a/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/MainWindow.axaml.cs
@@ -36,6 +36,18 @@ public partial class MainWindow : Window
         };
         Closing += (_, _) => SaveWindowPlacement();
 
+        // The title-bar nav buttons aren't TabItems, so tab selection can't style them
+        // via :selected - mirror CurrentTab onto an "active" style class instead.
+        DataContextChanged += (_, _) =>
+        {
+            if (DataContext is not MainWindowViewModel vm) return;
+            vm.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(MainWindowViewModel.CurrentTab)) UpdateActiveNavTab();
+            };
+            UpdateActiveNavTab();
+        };
+
         // Which panel is "active" changes on every tab switch and every time Home's log
         // or Community's article shows/hides, none of which fire a single one-shot event
         // we can hook. Recomputing on every layout pass keeps it in sync regardless of
@@ -111,6 +123,15 @@ public partial class MainWindow : Window
         if (ResizeGrips is not null) ResizeGrips.IsVisible = !maximized;
         if (MaximizeGlyph is not null) MaximizeGlyph.Text = maximized ? "❐" : "◻";
         if (MaximizeButton is not null) ToolTip.SetTip(MaximizeButton, maximized ? "Restore" : "Maximize");
+    }
+
+    private void UpdateActiveNavTab()
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        HomeNavButton?.Classes.Set("active", vm.CurrentTab == MainWindowViewModel.HomeTabId);
+        CommunityNavButton?.Classes.Set("active", vm.CurrentTab == MainWindowViewModel.CommunityTabId);
+        ModsNavButton?.Classes.Set("active", vm.CurrentTab == MainWindowViewModel.ModsTabId);
+        SettingsNavButton?.Classes.Set("active", vm.CurrentTab == MainWindowViewModel.SettingsTabId);
     }
 
     private void RefreshBackdropClips()


### PR DESCRIPTION
Stage 3 of the v0.3.0 redesign, stacked on #49.

Per the design: brand label top-left with the version in brand red, HOME / COMMUNITY / MODS text tabs plus the settings gear centered in the title bar, window buttons top-right, and a thin status strip along the bottom (READY / launcher-update-required warning left, active install name right).

Implementation notes:
- The TabControl stays as the content host. Its Names and CurrentTab semantics are what the backdrop-blur clips and the headless tests hang off, so only its header strip is hidden; the new title-bar buttons drive the existing GoToTabCommand.
- Active tab styling (white label + red underline) is an "active" style class mirrored from CurrentTab in code-behind, since plain Buttons have no :selected pseudoclass.
- Ctrl+1..4 and Escape are untouched; they always went through CurrentTab.
- The launcher-update-required state is now visible from every tab via the status bar instead of only on Home.

All 150 tests green. Verified visually: nav renders centered, underline follows tab switches (keyboard and mouse share the same CurrentTab path), status bar shows READY + install name.

Same stack note as #49: merge bottom-up into updater-v0.3.0, retargeting as each level lands.