### PR TITLE
Redesign the Home tab: hero, featured update panel, roadmap cards

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/HomeHeroTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/HeadlessTests/HomeHeroTest.cs
@@ -1,0 +1,141 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CodeHollow.FeedReader;
+using Ksp2Redux.Tools.Launcher.ViewModels;
+using Ksp2Redux.Tools.Launcher.ViewModels.Home;
+using Ksp2Redux.Tools.Launcher.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test.HeadlessTests;
+
+public class HomeHeroTest
+{
+    private static MainWindow ShowMainWindow()
+    {
+        TestAppBuilder.OperatingSystemService.Setup(o => o.IsLinux()).Returns(false);
+        TestAppBuilder.UpdateService.Setup(u => u.CheckAndPerformUpdateAsync()).Returns(Task.FromResult(true));
+        TestHelpers.MockMessageBoxAcceptAll();
+
+        MainWindow window = new MainWindow
+        {
+            DataContext = TestAppBuilder.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return window;
+    }
+
+    [AvaloniaTest]
+    public void FeaturedUpdatePanel_ShowsTheNewestNewsItem()
+    {
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed
+        {
+            Items =
+            [
+                new FeedItem
+                {
+                    Title = "Beta 6 - Hotfix 4",
+                    Content = "<p>SM+ heat shield, <b>procedural body flaps</b> and a batch of QoL fixes.</p>",
+                    Link = "https://ksp2redux.org/blog/beta-6-hotfix-4",
+                    PublishingDate = new DateTime(2026, 6, 30, 12, 0, 0, DateTimeKind.Utc),
+                },
+                new FeedItem
+                {
+                    Title = "Older post",
+                    Content = "<p>Old news.</p>",
+                    Link = "https://ksp2redux.org/blog/older",
+                    PublishingDate = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc),
+                },
+            ],
+        });
+
+        var window = ShowMainWindow();
+        var homeTab = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTab.HasFeaturedUpdate, Is.True);
+            Assert.That(homeTab.FeaturedTitle, Is.EqualTo("Beta 6 - Hotfix 4"), "The NEWEST item must be featured.");
+            Assert.That(homeTab.FeaturedExcerpt, Does.Contain("procedural body flaps"));
+            Assert.That(homeTab.FeaturedExcerpt, Does.Not.Contain("<"), "The excerpt must be plain text, not HTML.");
+            Assert.That(window.GetVisualDescendants().OfType<Border>().Any(b => b.Name == "FeaturedPanel"), Is.True);
+        });
+    }
+
+    [AvaloniaTest]
+    public void EmptyNewsFeed_HidesTheFeaturedPanelInsteadOfShowingAnEmptyShell()
+    {
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+
+        ShowMainWindow();
+        var homeTab = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        Assert.That(homeTab.HasFeaturedUpdate, Is.False);
+    }
+
+    [AvaloniaTest]
+    public void StatusChip_ReflectsTheInstalledGameVersion()
+    {
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+        TestHelpers.MockKsp2StockSteamInstall();
+
+        ShowMainWindow();
+        var homeTab = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTab.StatusChipOk, Is.True);
+            Assert.That(homeTab.StatusChipText, Does.StartWith("Ready - v"));
+        });
+    }
+
+    [AvaloniaTest]
+    public void NoInstallDetected_StatusChipSaysSo()
+    {
+        TestAppBuilder.NewsProviderService.Setup(n => n.GetSyndicationFeed()).ReturnsAsync(new Feed { Items = [] });
+
+        ShowMainWindow();
+        var homeTab = TestAppBuilder.ServiceProvider.GetRequiredService<HomeTabViewModel>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(homeTab.StatusChipOk, Is.False);
+            Assert.That(homeTab.StatusChipText, Is.EqualTo("Game not detected"));
+        });
+    }
+}
+
+public class ExtractPlainTextExcerptTest
+{
+    [Test]
+    public void StripsTagsDecodesEntitiesAndCollapsesWhitespace()
+    {
+        var html = "<p>We&apos;ve   just <b>released</b>\n a minor update.</p>";
+
+        Assert.That(HomeTabViewModel.ExtractPlainTextExcerpt(html), Is.EqualTo("We've just released a minor update."));
+    }
+
+    [Test]
+    public void LongContent_IsTruncatedAtAWordBoundaryWithEllipsis()
+    {
+        var html = string.Join(" ", Enumerable.Repeat("word", 200));
+
+        var excerpt = HomeTabViewModel.ExtractPlainTextExcerpt(html, maxLength: 50);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(excerpt, Does.EndWith("..."));
+            Assert.That(excerpt.Length, Is.LessThanOrEqualTo(53));
+            Assert.That(excerpt, Does.Not.Contain("wo..."), "Truncation must land on a word boundary.");
+        });
+    }
+
+    [Test]
+    public void EmptyContent_YieldsEmptyString()
+    {
+        Assert.That(HomeTabViewModel.ExtractPlainTextExcerpt(""), Is.Empty);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/HomeTabViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -86,6 +87,40 @@ public partial class HomeTabViewModel : ViewModelBase
     [ObservableProperty]
     public partial bool InstallationDisabled { get; set; }
 
+    // Featured update panel on the Home hero: mirrors the newest item from the same news
+    // feed the sidebar list shows, so there's no second fetch and no second source of truth.
+    [ObservableProperty]
+    public partial string? FeaturedTitle { get; set; }
+
+    [ObservableProperty]
+    public partial string? FeaturedDate { get; set; }
+
+    [ObservableProperty]
+    public partial string? FeaturedExcerpt { get; set; }
+
+    [ObservableProperty]
+    public partial string? FeaturedNewsId { get; set; }
+
+    [ObservableProperty]
+    public partial bool HasFeaturedUpdate { get; set; }
+
+    // Status chip in the Home hero ("Ready - v0.2.3.1 beta" with a green dot, or what's
+    // blocking that). Derived alongside the main button state, which already inspects
+    // exactly the same install facts.
+    [ObservableProperty]
+    public partial string StatusChipText { get; set; } = "Checking...";
+
+    [ObservableProperty]
+    public partial bool StatusChipOk { get; set; }
+
+    public IReadOnlyList<RoadmapCardViewModel> RoadmapCards { get; } =
+    [
+        new("Colonies", "In progress", true),
+        new("Resources", "In progress", true),
+        new("Interstellar", "Planned", false),
+        new("Multiplayer", "Planned", false),
+    ];
+
     private readonly StringBuilder _installLogBuilder = new();
     private readonly Lock _installLogLock = new();
     private bool _installLogUpdateQueued;
@@ -95,7 +130,8 @@ public partial class HomeTabViewModel : ViewModelBase
         item => (item as GameVersionViewModel)?.Channel ?? string.Empty;
 
     public HomeTabViewModel(IKsp2InstallService ksp2InstallService,
-        ILauncherConfigService launcherConfigService, IReleasesFeedService releasesFeedService, IInstallPlanService installPlanService, IUpdateService updateService, IOperatingSystemService operatingSystemService, IMessageBoxService messageBoxService, ILogService log)
+        ILauncherConfigService launcherConfigService, IReleasesFeedService releasesFeedService, IInstallPlanService installPlanService, IUpdateService updateService, IOperatingSystemService operatingSystemService, IMessageBoxService messageBoxService,
+        INewsItemCollectionService newsItemCollectionService, ILogService log)
     {
         _ksp2InstallService = ksp2InstallService;
         _launcherConfigService = launcherConfigService;
@@ -105,6 +141,12 @@ public partial class HomeTabViewModel : ViewModelBase
         _operatingSystemService = operatingSystemService;
         _messageBoxService = messageBoxService;
         _log = log;
+
+        // News loads asynchronously after startup, so react to the shared collection
+        // filling up rather than reading it once here.
+        newsItemCollectionService.NewsCollection.CollectionChanged += (_, _) =>
+            UpdateFeaturedUpdate(newsItemCollectionService.NewsCollection);
+        UpdateFeaturedUpdate(newsItemCollectionService.NewsCollection);
 
         RebuildInstallsCollection();
         RebuildVersionsCollection();
@@ -310,9 +352,64 @@ public partial class HomeTabViewModel : ViewModelBase
     
     public void RefreshMainButtonState() => UpdateMainButtonState();
 
+    private void UpdateFeaturedUpdate(IEnumerable<Shared.NewsItemViewModel> news)
+    {
+        var newest = news.OrderByDescending(n => n.Date).FirstOrDefault();
+        if (newest is null)
+        {
+            HasFeaturedUpdate = false;
+            return;
+        }
+
+        FeaturedTitle = newest.Title;
+        FeaturedDate = newest.Date.ToLocalTime().ToString("yyyy-MM-dd");
+        FeaturedExcerpt = ExtractPlainTextExcerpt(newest.Content);
+        FeaturedNewsId = newest.NewsId;
+        HasFeaturedUpdate = true;
+    }
+
+    // News content is blog HTML (rendered fully on the Community tab); the hero panel only
+    // wants a short plain-text teaser of it.
+    public static string ExtractPlainTextExcerpt(string html, int maxLength = 260)
+    {
+        if (string.IsNullOrWhiteSpace(html)) return string.Empty;
+
+        var text = System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", " ");
+        text = System.Net.WebUtility.HtmlDecode(text);
+        text = System.Text.RegularExpressions.Regex.Replace(text, @"\s+", " ").Trim();
+        if (text.Length <= maxLength) return text;
+
+        var cut = text.LastIndexOf(' ', maxLength);
+        if (cut <= 0) cut = maxLength;
+        return text[..cut].TrimEnd() + "...";
+    }
+
+    private void UpdateStatusChip()
+    {
+        var ksp2 = _ksp2InstallService.Ksp2;
+        if (ksp2 is null || !ksp2.IsValid)
+        {
+            StatusChipText = "Game not detected";
+            StatusChipOk = false;
+            return;
+        }
+
+        if (ksp2.GameVersion is null)
+        {
+            StatusChipText = "Game version unknown";
+            StatusChipOk = false;
+            return;
+        }
+
+        var version = ksp2.GameVersion;
+        StatusChipText = $"Ready - v{version.VersionNumber}.{version.BuildNumber} {version.Channel.ToLowerInvariant()}";
+        StatusChipOk = true;
+    }
+
     private void UpdateMainButtonState()
     {
         _ksp2InstallService.TryLoadKsp2Install();
+        UpdateStatusChip();
         var ksp2 = _ksp2InstallService.Ksp2;
         if (ksp2 is null || !ksp2.IsValid)
         {

--- a/Ksp2Redux.Tools.Launcher/ViewModels/Home/RoadmapCardViewModel.cs
+++ b/Ksp2Redux.Tools.Launcher/ViewModels/Home/RoadmapCardViewModel.cs
@@ -1,0 +1,12 @@
+namespace Ksp2Redux.Tools.Launcher.ViewModels.Home;
+
+/// <summary>
+/// One card in the Home hero's roadmap row. The roadmap is deliberately hardcoded in the
+/// launcher for now - it changes rarely enough that shipping a release for it is fine.
+/// </summary>
+public class RoadmapCardViewModel(string title, string statusText, bool inProgress) : ViewModelBase
+{
+    public string Title => title;
+    public string StatusText => statusText;
+    public bool InProgress => inProgress;
+}

--- a/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml
+++ b/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml
@@ -3,9 +3,18 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:home="clr-namespace:Ksp2Redux.Tools.Launcher.ViewModels.Home"
+             xmlns:converters="clr-namespace:Ksp2Redux.Tools.Launcher.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Ksp2Redux.Tools.Launcher.Views.HomeTabView"
              x:DataType="home:HomeTabViewModel">
+	<UserControl.Resources>
+		<converters:BoolToBrushConverter x:Key="RoadmapStatusBrushConverter"
+		                                 HeaderBrush="{StaticResource WarningBrush}"
+		                                 ItemBrush="{StaticResource TextSecondaryBrush}" />
+		<converters:BoolToBrushConverter x:Key="StatusChipBrushConverter"
+		                                 HeaderBrush="{StaticResource SuccessHoverBrush}"
+		                                 ItemBrush="{StaticResource WarningBrush}" />
+	</UserControl.Resources>
 	<UserControl.Styles>
 		<Style Selector="ProgressBar">
 			<Setter Property="Margin" Value="8"/>
@@ -51,6 +60,99 @@
 	</UserControl.Styles>
 
     <Grid>
+		<!-- Default Home state (hidden while an install/update runs and the log takes over):
+		     hero copy over the raw background art, the featured-update panel, and the
+		     roadmap row. The hero deliberately has NO glass panel - the design puts this
+		     text straight on the art. -->
+		<Grid IsVisible="{Binding IsInstallLogVisible, Converter={StaticResource InverseBoolConverter}}"
+		      Margin="24,8,24,8" RowDefinitions="*,Auto" ColumnDefinitions="*,340">
+			<StackPanel Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="16,0,32,0" Spacing="16">
+				<TextBlock Text="COMMUNITY CONTINUATION"
+				           FontFamily="{StaticResource JetBrainsMonoBold}" FontSize="11" LetterSpacing="4"
+				           Foreground="{StaticResource BrandRedBrush}" />
+				<TextBlock Text="KSP2 REDUX"
+				           FontFamily="{StaticResource JetBrainsMonoBold}" FontSize="48" LetterSpacing="5"
+				           Foreground="{StaticResource TextPrimaryBrush}" TextWrapping="Wrap" />
+				<TextBlock Text="Finishing Kerbal Space Program 2 the way it was meant to be - colonies, resources, interstellar travel and multiplayer."
+				           FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="13" LineHeight="22"
+				           Foreground="{StaticResource TextMutedBrush}" TextWrapping="Wrap" MaxWidth="520"
+				           HorizontalAlignment="Left" />
+				<Border HorizontalAlignment="Left" Padding="12,5"
+				        BorderThickness="1" CornerRadius="{StaticResource RadiusMedium}"
+				        BorderBrush="{Binding StatusChipOk, Converter={StaticResource StatusChipBrushConverter}}"
+				        Background="{StaticResource ScrimSoftBrush}">
+					<StackPanel Orientation="Horizontal" Spacing="8">
+						<Ellipse Width="7" Height="7" VerticalAlignment="Center"
+						         Fill="{Binding StatusChipOk, Converter={StaticResource StatusChipBrushConverter}}" />
+						<TextBlock Name="StatusChipText" Text="{Binding StatusChipText}"
+						           FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="11"
+						           Foreground="{Binding StatusChipOk, Converter={StaticResource StatusChipBrushConverter}}" />
+					</StackPanel>
+				</Border>
+			</StackPanel>
+
+			<Border Grid.Row="0" Grid.Column="1" Name="FeaturedPanel"
+			        IsVisible="{Binding HasFeaturedUpdate}"
+			        VerticalAlignment="Stretch"
+			        Background="{StaticResource GlassSurfaceBrush}"
+			        BorderBrush="{StaticResource GlassSurfaceBorderBrush}" BorderThickness="2"
+			        CornerRadius="{StaticResource RadiusLarge}" Padding="20">
+				<DockPanel LastChildFill="False">
+					<StackPanel DockPanel.Dock="Top" Spacing="10">
+						<TextBlock Text="FEATURED UPDATE"
+						           FontFamily="{StaticResource JetBrainsMonoBold}" FontSize="10" LetterSpacing="3"
+						           Foreground="{StaticResource BrandRedBrush}" />
+						<TextBlock Name="FeaturedTitle" Text="{Binding FeaturedTitle}"
+						           FontFamily="{StaticResource JetBrainsMonoBold}" FontSize="20"
+						           Foreground="{StaticResource TextPrimaryBrush}" TextWrapping="Wrap" />
+						<TextBlock Text="{Binding FeaturedDate}"
+						           FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="10" LetterSpacing="1"
+						           Foreground="{StaticResource BrandRedBrush}" />
+						<TextBlock Text="{Binding FeaturedExcerpt}"
+						           FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="11" LineHeight="19"
+						           Foreground="{StaticResource TextMutedBrush}" TextWrapping="Wrap" />
+					</StackPanel>
+					<Button DockPanel.Dock="Bottom" Name="ReadFullNotesButton" Classes="link-button"
+					        Click="ReadFullNotes_OnClick"
+					        Background="Transparent" BorderThickness="0" Padding="0" Cursor="Hand">
+						<TextBlock Text="Read full notes ›"
+						           FontFamily="{StaticResource JetBrainsMonoBold}" FontSize="11"
+						           Foreground="{StaticResource BrandRedBrush}" />
+					</Button>
+				</DockPanel>
+			</Border>
+
+			<ItemsControl Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+			              ItemsSource="{Binding RoadmapCards}" Margin="0,20,0,0">
+				<ItemsControl.ItemsPanel>
+					<ItemsPanelTemplate>
+						<UniformGrid Rows="1" Columns="4" />
+					</ItemsPanelTemplate>
+				</ItemsControl.ItemsPanel>
+				<ItemsControl.ItemTemplate>
+					<DataTemplate DataType="home:RoadmapCardViewModel">
+						<Border Margin="6,0" Padding="14,12"
+						        Background="{StaticResource GlassSurfaceBrush}"
+						        BorderBrush="{StaticResource GlassSurfaceBorderBrush}" BorderThickness="1"
+						        CornerRadius="{StaticResource RadiusMedium}">
+							<Grid ColumnDefinitions="*,Auto">
+								<StackPanel Grid.Column="0" Spacing="4">
+									<TextBlock Text="{Binding Title}"
+									           FontFamily="{StaticResource JetBrainsMonoBold}" FontSize="13"
+									           Foreground="{StaticResource TextPrimaryBrush}" />
+									<TextBlock Text="{Binding StatusText}"
+									           FontFamily="{StaticResource JetBrainsMonoRegular}" FontSize="10" LetterSpacing="1"
+									           Foreground="{Binding InProgress, Converter={StaticResource RoadmapStatusBrushConverter}}" />
+								</StackPanel>
+								<Ellipse Grid.Column="1" Width="6" Height="6" VerticalAlignment="Top"
+								         Fill="{StaticResource BrandRedBrush}" />
+							</Grid>
+						</Border>
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+		</Grid>
+
 		<Border x:Name="GlassPanel" BorderThickness="2" CornerRadius="{StaticResource RadiusLarge}"
 				BorderBrush="{StaticResource GlassSurfaceBorderBrush}" Background="{StaticResource GlassSurfaceBrush}"
 				BoxShadow="{StaticResource GlassPanelShadow}"

--- a/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml.cs
+++ b/Ksp2Redux.Tools.Launcher/Views/HomeTabView.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Ksp2Redux.Tools.Launcher.ViewModels;
 using Ksp2Redux.Tools.Launcher.ViewModels.Home;
 
 namespace Ksp2Redux.Tools.Launcher.Views;
@@ -28,5 +29,17 @@ public partial class HomeTabView : UserControl
         if (InstallLogTextBoxControl is not { } installLogTextBox) return;
         var lastLineIndex = Math.Max(0, installLogTextBox.GetLineCount() - 1);
         installLogTextBox.ScrollToLine(lastLineIndex);
+    }
+
+    // Same navigation the sidebar news items use (NewsItemView.NewsPanel_OnPointerPressed):
+    // select the article on the Community tab, then switch to it.
+    private void ReadFullNotes_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (TopLevel.GetTopLevel(this) is not MainWindow { DataContext: MainWindowViewModel mainWindowViewModel })
+            return;
+        if (Model?.FeaturedNewsId is not { } newsId) return;
+
+        mainWindowViewModel.CommunityTab.SetSelectedNewsId(newsId);
+        mainWindowViewModel.CurrentTab = MainWindowViewModel.CommunityTabId;
     }
 }


### PR DESCRIPTION
Stage 4 of the v0.3.0 redesign, stacked on #50. This is the visual centerpiece from the Claude Design mockup.

The default Home state (no install log showing) now has:
- Hero copy straight on the background art: COMMUNITY CONTINUATION eyebrow, big KSP2 REDUX title (wraps to two lines at narrow widths), mission statement
- A status chip that tells the truth about the install: green "Ready - v0.2.3.1 beta", or "Game not detected" / "Game version unknown" in warning yellow
- FEATURED UPDATE panel mirroring the newest item from the same news feed the sidebar shows - no second fetch, no second source of truth. HTML stripped to a plain-text teaser; "Read full notes" jumps to that article on the Community tab via the exact navigation the sidebar items use
- Four roadmap cards along the bottom (Colonies and Resources in progress, Interstellar and Multiplayer planned), hardcoded by design

The install-log glass panel is untouched and still swaps in over the hero during installs, so the backdrop-blur clip logic keeps tracking the same panel it always did.

7 new tests (featured mapping incl. newest-item selection and HTML stripping, empty-feed fallback, status chip states, excerpt utility edge cases). Full suite green at 157/157. Verified visually at 1280x800: hero, chip, featured panel, roadmap row and status bar all match the mockup layout.

Same stack note: merge bottom-up (#48 -> #49 -> #50 -> this) into updater-v0.3.0, retargeting as each level lands.