### PR TITLE
Updater v0.3.1: fix false 'not enough disk space' error on Linux

### DIFF
--- a/Ksp2Redux.Tools.Launcher.Test/DiskSpaceServiceTest.cs
+++ b/Ksp2Redux.Tools.Launcher.Test/DiskSpaceServiceTest.cs
@@ -1,0 +1,96 @@
+using System.IO.Abstractions;
+using Ksp2Redux.Tools.Launcher.Services;
+using Moq;
+
+namespace Ksp2Redux.Tools.Launcher.Test;
+
+public class DiskSpaceServiceTest
+{
+    private const long OneGb = 1024L * 1024 * 1024;
+
+    private static (Mock<IFileSystem> Fs, Mock<IPath> Path, Mock<IDirectory> Directory, Mock<IDriveInfoFactory> Drives)
+        MakeFileSystemMock()
+    {
+        var fs = new Mock<IFileSystem>();
+        var path = new Mock<IPath>();
+        var directory = new Mock<IDirectory>();
+        var drives = new Mock<IDriveInfoFactory>();
+        fs.SetupGet(f => f.Path).Returns(path.Object);
+        fs.SetupGet(f => f.Directory).Returns(directory.Object);
+        fs.SetupGet(f => f.DriveInfo).Returns(drives.Object);
+        return (fs, path, directory, drives);
+    }
+
+    private static Mock<IDriveInfo> DriveWithFreeSpace(long bytes)
+    {
+        var drive = new Mock<IDriveInfo>();
+        drive.SetupGet(d => d.AvailableFreeSpace).Returns(bytes);
+        return drive;
+    }
+
+    [Test]
+    public void GetAvailableFreeSpace_UnixPath_QueriesTheDirectoryItselfNotTheRoot()
+    {
+        // On SteamOS the rootfs ("/") is a tiny separate partition from /home, where games live.
+        // Querying "/" reported ~1 GB free even though the install drive had >100 GB (issue seen
+        // on Steam Deck). The service must hand the install directory itself to DriveInfo.
+        const string installDir = "/home/deck/.local/share/Steam/steamapps/common/Kerbal Space Program 2";
+        var (fs, path, directory, drives) = MakeFileSystemMock();
+        path.Setup(p => p.GetFullPath(installDir)).Returns(installDir);
+        path.Setup(p => p.GetPathRoot(installDir)).Returns("/");
+        directory.Setup(d => d.Exists(installDir)).Returns(true);
+        drives.Setup(f => f.New(installDir)).Returns(DriveWithFreeSpace(119 * OneGb).Object);
+
+        var result = new DiskSpaceService(fs.Object).GetAvailableFreeSpace(installDir);
+
+        Assert.That(result, Is.EqualTo(119 * OneGb));
+        drives.Verify(f => f.New("/"), Times.Never);
+    }
+
+    [Test]
+    public void GetAvailableFreeSpace_UnixPathDoesNotExist_WalksUpToDeepestExistingDirectory()
+    {
+        const string missingDir = "/home/deck/Games/NotThereYet";
+        const string existingParent = "/home/deck/Games";
+        var (fs, path, directory, drives) = MakeFileSystemMock();
+        path.Setup(p => p.GetFullPath(missingDir)).Returns(missingDir);
+        path.Setup(p => p.GetPathRoot(missingDir)).Returns("/");
+        path.Setup(p => p.GetDirectoryName(missingDir)).Returns(existingParent);
+        directory.Setup(d => d.Exists(missingDir)).Returns(false);
+        directory.Setup(d => d.Exists(existingParent)).Returns(true);
+        drives.Setup(f => f.New(existingParent)).Returns(DriveWithFreeSpace(50 * OneGb).Object);
+
+        var result = new DiskSpaceService(fs.Object).GetAvailableFreeSpace(missingDir);
+
+        Assert.That(result, Is.EqualTo(50 * OneGb));
+    }
+
+    [Test]
+    public void GetAvailableFreeSpace_WindowsPath_QueriesTheDriveRoot()
+    {
+        const string installDir = @"C:\Games\Ksp2";
+        const string root = @"C:\";
+        var (fs, path, _, drives) = MakeFileSystemMock();
+        path.Setup(p => p.GetFullPath(installDir)).Returns(installDir);
+        path.Setup(p => p.GetPathRoot(installDir)).Returns(root);
+        drives.Setup(f => f.New(root)).Returns(DriveWithFreeSpace(200 * OneGb).Object);
+
+        var result = new DiskSpaceService(fs.Object).GetAvailableFreeSpace(installDir);
+
+        Assert.That(result, Is.EqualTo(200 * OneGb));
+    }
+
+    [Test]
+    public void GetAvailableFreeSpace_DriveQueryFails_ReturnsNull()
+    {
+        const string installDir = @"C:\Games\Ksp2";
+        var (fs, path, _, drives) = MakeFileSystemMock();
+        path.Setup(p => p.GetFullPath(installDir)).Returns(installDir);
+        path.Setup(p => p.GetPathRoot(installDir)).Returns(@"C:\");
+        drives.Setup(f => f.New(It.IsAny<string>())).Throws(new IOException("no such device"));
+
+        var result = new DiskSpaceService(fs.Object).GetAvailableFreeSpace(installDir);
+
+        Assert.That(result, Is.Null);
+    }
+}

--- a/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
+++ b/Ksp2Redux.Tools.Launcher/Ksp2Redux.Tools.Launcher.csproj
@@ -12,7 +12,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <LangVersion>preview</LangVersion>
-        <Version>0.3.0</Version>
+        <Version>0.3.1</Version>
         <AssemblyTitle>KSP2 Redux</AssemblyTitle>
         <Product>KSP2 Redux</Product>
         <Company>KSP2 Redux</Company>

--- a/Ksp2Redux.Tools.Launcher/Services/DiskSpaceService.cs
+++ b/Ksp2Redux.Tools.Launcher/Services/DiskSpaceService.cs
@@ -17,12 +17,27 @@ public class DiskSpaceService(IFileSystem fileSystem) : IDiskSpaceService
 {
     public long? GetAvailableFreeSpace(string path)
     {
-        var root = fileSystem.Path.GetPathRoot(fileSystem.Path.GetFullPath(path));
-        if (string.IsNullOrEmpty(root)) return null;
-
         try
         {
-            return fileSystem.DriveInfo.New(root).AvailableFreeSpace;
+            var fullPath = fileSystem.Path.GetFullPath(path);
+            var root = fileSystem.Path.GetPathRoot(fullPath);
+            if (string.IsNullOrEmpty(root)) return null;
+
+            // On Unix the path root is always "/", which can be a different (and much smaller) mount
+            // than the one actually holding the path - e.g. SteamOS has a ~5 GB rootfs while games
+            // live on the separate /home partition. Unix DriveInfo reports on the filesystem of
+            // exactly the path it is given, so query the deepest existing directory of the path.
+            // Windows DriveInfo only accepts drive roots, so keep querying the root there.
+            var query = root;
+            if (root == "/")
+            {
+                var probe = fullPath;
+                while (!string.IsNullOrEmpty(probe) && !fileSystem.Directory.Exists(probe))
+                    probe = fileSystem.Path.GetDirectoryName(probe);
+                if (!string.IsNullOrEmpty(probe)) query = probe;
+            }
+
+            return fileSystem.DriveInfo.New(query).AvailableFreeSpace;
         }
         catch (ArgumentException)
         {


### PR DESCRIPTION
## Summary

Fixes the false **"Not enough free disk space to continue"** error reported on Steam Deck, where the installer claimed only 1.3 GB was available while the install drive had 100+ GB free.

## Root cause

`DiskSpaceService.GetAvailableFreeSpace` queried `DriveInfo` with `Path.GetPathRoot()`. On Windows that's the drive letter and works fine, but on Linux the path root is always `/` — so the pre-flight check measured the rootfs partition instead of the mount actually holding the install. On SteamOS the rootfs is a small (~5 GB) partition with ~1.3 GB free, while games live on the separate `/home` partition. Any Linux setup where the install sits on a different mount than `/` (Steam Deck `/home`, SD cards, etc.) hit this.

## Fix

Unix `DriveInfo` reports on the filesystem of exactly the path it is given (`statvfs`), so when the path root is `/` we now query the deepest existing directory of the install path instead of the root. Windows behavior is unchanged. Verified empirically that both plain `DriveInfo` and the Testably `RealFileSystem` wrapper used in production pass a directory path through untouched.

Also bumps the launcher version to 0.3.1.

## Tests

New `DiskSpaceServiceTest` covers:
- the Steam Deck regression: a Unix path must be queried directly, never `/`
- walking up to the deepest existing parent for not-yet-created paths
- Windows still queries the drive root
- query failure returns null (space check skipped)

Full solution suite passes: 154/154.